### PR TITLE
Fix lost disconnect events in connection history tracking

### DIFF
--- a/app.py
+++ b/app.py
@@ -1829,7 +1829,15 @@ def _poll_loop():
                                 _kiosk_temp_conns.pop((node_str, peer), None)
                             _link_prunes.append((node_str, peer))
                             _forget_keyed(peer)
-                        _prev_connected_map[node_str] = est_set
+                        # Keep tracking a peer as "open" for as long as it stays in
+                        # all_set, even on a cycle where link_connect_state briefly
+                        # reports something other than ESTABLISHED (a normal blip
+                        # during teardown/renegotiation). Resetting this to est_set
+                        # unconditionally would drop the peer from prev_est on that
+                        # blip without firing a close (still in all_set that cycle),
+                        # and then the close would be silently lost forever once the
+                        # peer actually disappears, since prev_est no longer has it.
+                        _prev_connected_map[node_str] = (prev_est | est_set) & all_set
 
                         # Kiosk idle-timeout: update last_active when local or peer is keyed.
                         # Skip entries that are genuinely permanent (ilink 12/13) OR have had


### PR DESCRIPTION
## Summary
- A node connected overnight (K8SN on node 2324) and dropped, but never showed up as closed in the Recent Connections panel — the DB row stayed open with no `disconnected_at`, even though the node genuinely wasn't connected anymore and HenWen hadn't restarted.
- Root cause: `_prev_connected_map` (used to diff established peers cycle-to-cycle in the AMI poll loop) was reset to only currently-`ESTABLISHED` peers every cycle. If a link's `link_connect_state` briefly reported something other than `ESTABLISHED` while still present in the raw connected list — a normal blip during teardown — the peer fell out of tracking *before* the close diff could fire. On the next cycle, once the peer was actually gone, there was nothing left in `prev_est` to diff against, so the disconnect event was silently lost forever.
- Fix: keep a peer tracked as "open" for as long as it remains in the raw connected list, not just while its state reads `ESTABLISHED`, so a transient state flicker can't erase the close-detection memory.

## Test plan
- [x] Confirmed via `journalctl`/DB inspection on the live instance that the stuck row (connected 21:54, never closed) matched this exact failure mode, and that `rpt lstats` showed the node genuinely disconnected with no HenWen restart in between.
- [x] Deployed the fix to the live service and confirmed the AMI poller restarts cleanly.
- [ ] No automated test added — this logic lives inside `_poll_loop()`, which requires a live AMI connection to exercise (see CLAUDE.md Testing section: AMI client/poll loops aren't covered by the pytest suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBGy3jj8ByoqXWuJSFBqaS