### PR TITLE
Squash duplicate Meshtastic messages from multiple MQTT gateways

### DIFF
--- a/app.py
+++ b/app.py
@@ -760,8 +760,16 @@ def get_db():
         id        INTEGER PRIMARY KEY AUTOINCREMENT,
         from_node TEXT NOT NULL,
         text      TEXT NOT NULL,
-        ts        REAL NOT NULL
+        ts        REAL NOT NULL,
+        packet_id INTEGER NOT NULL DEFAULT 0
     )""")
+    if 'packet_id' not in {r[1] for r in conn.execute("PRAGMA table_info(meshtastic_messages)").fetchall()}:
+        # The originating node's packet id -- identical across every relay
+        # hop and every MQTT gateway that uplinks the same over-the-air
+        # packet, so it's what _meshtastic_on_message() dedups on. Existing
+        # rows default to 0, which just means they're never matched as a
+        # duplicate of anything (harmless -- they're already displayed).
+        conn.execute("ALTER TABLE meshtastic_messages ADD COLUMN packet_id INTEGER NOT NULL DEFAULT 0")
     conn.commit()
     # Node-id -> friendly-name lookup for the Meshtastic panel, built from
     # NODEINFO_APP packets a node broadcasts periodically alongside its text
@@ -2977,7 +2985,7 @@ MESHTASTIC_MQTT_USERNAME = "meshdev"
 MESHTASTIC_MQTT_PASSWORD = "large4cats"
 MESHTASTIC_CACHE_MAX = 50
 
-_meshtastic_cache = deque(maxlen=MESHTASTIC_CACHE_MAX)   # newest last; each {"from_node","text","ts"}
+_meshtastic_cache = deque(maxlen=MESHTASTIC_CACHE_MAX)   # newest last; each {"from_node","packet_id","text","ts"}
 _meshtastic_names_cache = {}   # node_id ("!xxxxxxxx") -> {"short_name","long_name","ts"}
 _meshtastic_lock = threading.Lock()
 # Raw-vs-decoded counters, reset and logged every ~30s by _meshtastic_poll_loop
@@ -2989,6 +2997,7 @@ _meshtastic_lock = threading.Lock()
 # from the logs alone -- these counters exist to tell those two apart.
 _meshtastic_raw_count = 0
 _meshtastic_decoded_count = 0
+_meshtastic_dup_count = 0
 
 
 def _remember_meshtastic_node_name(nodeinfo):
@@ -3015,7 +3024,7 @@ def _remember_meshtastic_node_name(nodeinfo):
 
 
 def _meshtastic_on_message(psk, msg):
-    global _meshtastic_raw_count, _meshtastic_decoded_count
+    global _meshtastic_raw_count, _meshtastic_decoded_count, _meshtastic_dup_count
     with _meshtastic_lock:
         _meshtastic_raw_count += 1
 
@@ -3045,8 +3054,28 @@ def _meshtastic_on_message(psk, msg):
     result["ts"] = time.time()
     with _meshtastic_lock:
         _meshtastic_decoded_count += 1
-        _meshtastic_cache.append(result)
-        name_info = _meshtastic_names_cache.get(result["from_node"])
+        # A node's original transmission is routinely heard -- and uplinked
+        # to MQTT -- by more than one gateway node in range, each publishing
+        # its own byte-identical copy of the same over-the-air packet. Every
+        # copy decrypts to the same (from_node, packet_id) pair (packet_id
+        # is assigned once by the originating node and never changes across
+        # relay hops), which is what makes it a safe dedup key -- unlike
+        # text content alone, it doesn't collide with a genuine second
+        # send of the same words (that gets its own fresh packet_id). Only
+        # checked against what's still in the display cache (recent
+        # duplicates arrive within seconds of each other via different
+        # gateways; anything older has already scrolled off-screen anyway).
+        is_dup = any(
+            c["from_node"] == result["from_node"] and c.get("packet_id") == result["packet_id"]
+            for c in _meshtastic_cache
+        )
+        if is_dup:
+            _meshtastic_dup_count += 1
+        else:
+            _meshtastic_cache.append(result)
+            name_info = _meshtastic_names_cache.get(result["from_node"])
+    if is_dup:
+        return
     display_name = name_info["short_name"] if name_info and name_info["short_name"] else result["from_node"]
     try:
         _meshtastic_discord_relay_queue.put_nowait((display_name, result["text"]))
@@ -3055,8 +3084,8 @@ def _meshtastic_on_message(psk, msg):
     try:
         db = get_db()
         db.execute(
-            "INSERT INTO meshtastic_messages (from_node, text, ts) VALUES (?, ?, ?)",
-            (result["from_node"], result["text"], result["ts"])
+            "INSERT INTO meshtastic_messages (from_node, text, ts, packet_id) VALUES (?, ?, ?, ?)",
+            (result["from_node"], result["text"], result["ts"], result["packet_id"])
         )
         # Keep only the newest MESHTASTIC_CACHE_MAX rows -- this table is a
         # restart-survival mirror of the cache, not a growing history log.
@@ -3112,7 +3141,7 @@ def start_meshtastic_discord_relay_worker():
 
 
 def _meshtastic_poll_loop():
-    global _meshtastic_raw_count, _meshtastic_decoded_count
+    global _meshtastic_raw_count, _meshtastic_decoded_count, _meshtastic_dup_count
     if mqtt_client is None or meshtastic_mqtt is None:
         log("WARN", "[MESHTASTIC] paho-mqtt not installed — Meshtastic panel disabled")
         return
@@ -3178,12 +3207,14 @@ def _meshtastic_poll_loop():
                 if disconnected.is_set():
                     break
                 with _meshtastic_lock:
-                    raw, decoded = _meshtastic_raw_count, _meshtastic_decoded_count
+                    raw, decoded, dups = _meshtastic_raw_count, _meshtastic_decoded_count, _meshtastic_dup_count
                     _meshtastic_raw_count = 0
                     _meshtastic_decoded_count = 0
+                    _meshtastic_dup_count = 0
                 if raw:
                     log("INFO", f"[MESHTASTIC] {raw} MQTT message(s) received on {topic!r} in the "
-                                 f"last ~30s, {decoded} decoded as text")
+                                 f"last ~30s, {decoded} decoded as text ({dups} of those squashed as "
+                                 f"duplicates already shown)")
                 if (_get_meshtastic_config() or MESHTASTIC_CONFIG_DEFAULTS) != cfg:
                     log("INFO", "[MESHTASTIC] Config changed — reconnecting")
                     break
@@ -3206,11 +3237,14 @@ def start_meshtastic_poller():
     # this is a one-shot reload, not something the poll loop itself repeats.
     try:
         rows = get_db().execute(
-            "SELECT from_node, text, ts FROM meshtastic_messages ORDER BY id ASC"
+            "SELECT from_node, text, ts, packet_id FROM meshtastic_messages ORDER BY id ASC"
         ).fetchall()
         with _meshtastic_lock:
             for r in rows:
-                _meshtastic_cache.append({"from_node": r["from_node"], "text": r["text"], "ts": r["ts"]})
+                _meshtastic_cache.append({
+                    "from_node": r["from_node"], "text": r["text"], "ts": r["ts"],
+                    "packet_id": r["packet_id"],
+                })
         if rows:
             log("INFO", f"[MESHTASTIC] Reloaded {len(rows)} persisted message(s) into cache")
     except Exception as e:

--- a/meshtastic_mqtt.py
+++ b/meshtastic_mqtt.py
@@ -83,9 +83,14 @@ def _build_nonce(packet_id: int, from_node: int) -> bytes:
 def _decrypt_packet_data(raw_bytes: bytes, psk_b64: str):
     """Shared envelope-parse + AES-CTR-decrypt + Data-parse step behind both
     decode_service_envelope() (text messages) and decode_nodeinfo() (name
-    lookups) — returns (from_node: int, data: mesh_min_pb2.Data), or None on
-    any failure (wrong/malformed PSK, not actually encrypted, or corrupt
-    data). Doesn't look at `data.portnum` itself — that's each caller's job.
+    lookups) — returns (from_node: int, packet_id: int, data:
+    mesh_min_pb2.Data), or None on any failure (wrong/malformed PSK, not
+    actually encrypted, or corrupt data). Doesn't look at `data.portnum`
+    itself — that's each caller's job. packet_id is the originating node's
+    packet id, which stays identical across every relay hop and every MQTT
+    gateway that uplinks the same over-the-air packet — decode_service_envelope()
+    surfaces it so a caller can dedup the same message arriving more than
+    once from different gateways.
     """
     try:
         key = derive_key(psk_b64)
@@ -104,7 +109,8 @@ def _decrypt_packet_data(raw_bytes: bytes, psk_b64: str):
         return None  # no ciphertext (e.g. an already-plaintext admin message) — not our concern
 
     from_node = getattr(packet, "from")
-    nonce = _build_nonce(getattr(packet, "id"), from_node)
+    packet_id = getattr(packet, "id")
+    nonce = _build_nonce(packet_id, from_node)
     decryptor = Cipher(algorithms.AES(key), modes.CTR(nonce)).decryptor()
     try:
         plaintext = decryptor.update(encrypted) + decryptor.finalize()
@@ -117,17 +123,21 @@ def _decrypt_packet_data(raw_bytes: bytes, psk_b64: str):
     except DecodeError:
         return None
 
-    return from_node, data
+    return from_node, packet_id, data
 
 
 def decode_service_envelope(raw_bytes: bytes, psk_b64: str) -> dict | None:
     """Decode one MQTT message payload into
-    `{"from_node": "!xxxxxxxx", "text": str, "ts": None}`, or None if it
-    isn't a decodable public-channel text message (wrong/malformed PSK,
-    not a text message, not actually encrypted, or corrupt data).
+    `{"from_node": "!xxxxxxxx", "packet_id": int, "text": str, "ts": None}`,
+    or None if it isn't a decodable public-channel text message
+    (wrong/malformed PSK, not a text message, not actually encrypted, or
+    corrupt data).
 
     `ts` is left for the caller to fill in (wall-clock receipt time isn't
-    this function's concern — it's a pure decode step).
+    this function's concern — it's a pure decode step). `packet_id` is the
+    originating node's packet id (see _decrypt_packet_data's docstring) —
+    exposed so a caller can dedup the same over-the-air packet arriving
+    more than once, once per MQTT gateway node that happened to hear it.
 
     Channel-PSK encryption here is unauthenticated (no MAC/auth tag,
     unlike the PKI direct-message path) — a wrong key doesn't reliably
@@ -138,7 +148,7 @@ def decode_service_envelope(raw_bytes: bytes, psk_b64: str) -> dict | None:
     decrypted = _decrypt_packet_data(raw_bytes, psk_b64)
     if decrypted is None:
         return None
-    from_node, data = decrypted
+    from_node, packet_id, data = decrypted
 
     if data.portnum != _TEXT_MESSAGE_APP:
         return None
@@ -152,6 +162,7 @@ def decode_service_envelope(raw_bytes: bytes, psk_b64: str) -> dict | None:
 
     return {
         "from_node": f"!{from_node:08x}",
+        "packet_id": packet_id,
         "text": text,
         "ts": None,
     }
@@ -169,7 +180,7 @@ def decode_nodeinfo(raw_bytes: bytes, psk_b64: str) -> dict | None:
     decrypted = _decrypt_packet_data(raw_bytes, psk_b64)
     if decrypted is None:
         return None
-    from_node, data = decrypted
+    from_node, _packet_id, data = decrypted
 
     if data.portnum != _NODEINFO_APP:
         return None

--- a/tests/test_meshtastic.py
+++ b/tests/test_meshtastic.py
@@ -96,7 +96,7 @@ class TestDecodeServiceEnvelope:
         raw = _build_envelope("MA==", self.TEXT, "Hello Michigan mesh!".encode("utf-8"),
                                packet_id=42, from_node=0xAABBCC11)
         result = meshtastic_mqtt.decode_service_envelope(raw, "MA==")
-        assert result == {"from_node": "!aabbcc11", "text": "Hello Michigan mesh!", "ts": None}
+        assert result == {"from_node": "!aabbcc11", "packet_id": 42, "text": "Hello Michigan mesh!", "ts": None}
 
     def test_wrong_psk_does_not_return_a_fake_message(self):
         raw = _build_envelope("MA==", self.TEXT, b"Hello Michigan mesh!")
@@ -269,6 +269,44 @@ class TestMeshtasticPersistence:
         assert rows[0]["text"] == "hello mesh"
         assert len(app._meshtastic_cache) == 1
 
+    def test_duplicate_packet_from_a_second_gateway_is_squashed(self, fresh_db):
+        # Same over-the-air packet, uplinked to MQTT by two different
+        # gateway nodes that both happened to hear it -- byte-identical
+        # ciphertext, so it decrypts to the same (from_node, packet_id)
+        # pair each time.
+        class _FakeMsg:
+            payload = _build_envelope("AQ==", portnums_pb2.PortNum.TEXT_MESSAGE_APP,
+                                       b"hello mesh", packet_id=777, from_node=0xAABBCC11)
+
+        app._meshtastic_on_message("AQ==", _FakeMsg())
+        app._meshtastic_on_message("AQ==", _FakeMsg())
+
+        assert len(app._meshtastic_cache) == 1
+        rows = app.get_db().execute("SELECT text FROM meshtastic_messages").fetchall()
+        assert len(rows) == 1
+
+    def test_same_text_different_packet_id_is_not_squashed(self, fresh_db):
+        # A genuine second send of identical words gets its own fresh
+        # packet_id from the sending node -- must not be treated as a dup.
+        for packet_id in (1, 2):
+            class _FakeMsg:
+                payload = _build_envelope("AQ==", portnums_pb2.PortNum.TEXT_MESSAGE_APP,
+                                           b"hello mesh", packet_id=packet_id, from_node=0xAABBCC11)
+            app._meshtastic_on_message("AQ==", _FakeMsg())
+
+        assert len(app._meshtastic_cache) == 2
+
+    def test_same_packet_id_different_sender_is_not_squashed(self, fresh_db):
+        # packet_id alone isn't unique network-wide -- only (from_node,
+        # packet_id) together identifies one original transmission.
+        for from_node in (0xAABBCC11, 0xDDEEFF22):
+            class _FakeMsg:
+                payload = _build_envelope("AQ==", portnums_pb2.PortNum.TEXT_MESSAGE_APP,
+                                           b"hello mesh", packet_id=555, from_node=from_node)
+            app._meshtastic_on_message("AQ==", _FakeMsg())
+
+        assert len(app._meshtastic_cache) == 2
+
     def test_persisted_rows_pruned_to_cache_max(self, fresh_db, monkeypatch):
         monkeypatch.setattr(app, "MESHTASTIC_CACHE_MAX", 3)
         for i in range(5):
@@ -296,7 +334,7 @@ class TestMeshtasticPersistence:
         app.start_meshtastic_poller()
 
         assert list(app._meshtastic_cache) == [
-            {"from_node": "!aabbccdd", "text": "reseeded message", "ts": 1234.0}
+            {"from_node": "!aabbccdd", "text": "reseeded message", "ts": 1234.0, "packet_id": 0}
         ]
 
     def test_nodeinfo_message_updates_name_cache_not_message_cache(self, fresh_db):

--- a/tests/test_meshtastic_discord_relay.py
+++ b/tests/test_meshtastic_discord_relay.py
@@ -200,6 +200,18 @@ class TestMeshtasticOnMessageEnqueuesDiscordRelay:
 
         assert app._meshtastic_discord_relay_queue.empty()
 
+    def test_duplicate_packet_is_not_re_enqueued(self, fresh_db):
+        # Same over-the-air packet uplinked by a second MQTT gateway --
+        # must not double-post to Discord.
+        class _FakeMsg:
+            payload = _build_envelope("AQ==", portnums_pb2.PortNum.TEXT_MESSAGE_APP, b"hello mesh",
+                                       packet_id=999, from_node=0xAABBCC11)
+
+        app._meshtastic_on_message("AQ==", _FakeMsg())
+        app._meshtastic_on_message("AQ==", _FakeMsg())
+
+        assert app._meshtastic_discord_relay_queue.qsize() == 1
+
     def test_full_queue_drops_message_instead_of_raising(self, fresh_db, monkeypatch):
         monkeypatch.setattr(app, "_meshtastic_discord_relay_queue", _queue_mod.Queue(maxsize=1))
         app._meshtastic_discord_relay_queue.put_nowait(("someone", "already queued"))


### PR DESCRIPTION
## Summary
- The same over-the-air Meshtastic packet is routinely heard and uplinked to MQTT by more than one gateway node in range, each publishing a byte-identical copy — this was showing up in the kiosk panel (and the Discord relay) as the same message appearing two or three times.
- Dedup key is `(from_node, packet_id)`: `packet_id` is assigned once by the originating node and stays constant across every relay hop, so it safely distinguishes "same packet, multiple gateways" from a genuine repeat send of identical text (which gets its own fresh `packet_id`).
- `decode_service_envelope()` now surfaces `packet_id`; `_meshtastic_on_message()` drops a duplicate before it reaches the display cache, the `meshtastic_messages` persistence table, or the Discord relay queue.
- Stacked on #5 (adds `packet_id` on top of that PR's `meshtastic_messages` schema/cache shape).

## Test plan
- [x] `pytest tests/test_meshtastic.py tests/test_meshtastic_discord_relay.py` — 59 passed, including new coverage for duplicate-squashing and its edge cases (same text/different packet id, same packet id/different sender, duplicate not re-relayed to Discord)
- [x] Full suite (`pytest`) — 398 passed
- [x] Deployed to the live HenWen instance and restarted; Meshtastic MQTT reconnected cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQgpFrUuPxhZ9aisqC1aao