### PR TITLE
Fix header button height mismatch on kiosk board

### DIFF
--- a/templates/status.html
+++ b/templates/status.html
@@ -178,7 +178,7 @@ html, body { height: 100%; background: var(--bg); color: var(--text);
 .btn-icon { background: var(--bg3); border: 1px solid var(--border); color: var(--text2);
   border-radius: 6px; padding: 4px 10px; cursor: pointer; font-size: 0.82rem;
   text-decoration: none; display: inline-flex; align-items: center; gap: 4px;
-  transition: color .15s, border-color .15s; }
+  line-height: 1; transition: color .15s, border-color .15s; }
 .btn-icon:hover { color: var(--text); border-color: var(--text2); }
 
 /* Header's utility row (search/net-schedule/login/layout-edit/fullscreen/


### PR DESCRIPTION
## Summary
- The Accessible/Login header buttons rendered taller than the icon buttons next to them (Search, Net Schedule, Fullscreen, Manager, etc.)
- Cause: `.btn-icon` buttons are `inline-flex`, so each button's height is its own content height. Icon buttons size to their SVG's exact `1em`, but the text-only buttons had no `line-height` set and fell back to the browser default (~1.15-1.2x font-size), making them taller.
- Fix: add `line-height: 1` to the shared `.btn-icon` rule so text-only buttons match the icon buttons' height.

## Test plan
- [ ] Load the kiosk board (`/`) and confirm all header buttons (Search, Net Schedule, Login, Hidden panels, Rearrange, Fullscreen, Accessible, Manager) are the same height
- [ ] Spot-check the Listen/TX/Record buttons on the Status Board (icon+text combos) still look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQgpFrUuPxhZ9aisqC1aao