### PR TITLE
Make chat message retention time an owner-selected setting

### DIFF
--- a/app.py
+++ b/app.py
@@ -220,10 +220,14 @@ LOGIN_LOCKOUT_MAX_SEC   = 900        # cap (15 min); doubles each additional fai
 PASSWORD_MIN_LEN = 8
 PASSWORD_MAX_LEN = 256
 
-# Kiosk chat panel (logged-in users only). Local, fixed ceilings rather than
-# a settings-table/UI, same "simple, hardcoded" posture as the NWS/APRS
-# staleness ceilings — storage cost is small enough (worst case ~5000 rows *
-# ~600 bytes/row, a few MB) that a configurable cap isn't worth the surface.
+# Kiosk chat panel (logged-in users only). Message length and the hard row
+# cap stay fixed, local ceilings -- storage cost is small enough (worst case
+# ~5000 rows * ~600 bytes/row, a few MB) that a configurable cap isn't worth
+# the surface. Retention *time*, though, is an owner-facing Kiosk Setting
+# (see api_kiosk_settings_get/put and 'kiosk_chat_retention_hours' in the
+# settings table) since how long chat history should stick around is a
+# real per-club judgment call, not an implementation ceiling -- this
+# constant is only the seeded default for a fresh install.
 CHAT_MESSAGE_MAX_LEN = 500
 CHAT_RETENTION_HOURS = 24
 CHAT_LOG_MAX_ROWS    = 5000
@@ -1118,6 +1122,7 @@ def get_db():
         ('kiosk_idle_timeout_sec', '600'),
         ('kiosk_clock_format',     '12'),
         ('kiosk_timezone',         'UTC'),
+        ('kiosk_chat_retention_hours', str(CHAT_RETENTION_HOURS)),
     ]:
         conn.execute("INSERT OR IGNORE INTO settings (key,value) VALUES (?,?)", (_k, _v))
     conn.commit()
@@ -5633,6 +5638,8 @@ def api_kiosk_settings_get():
         "clock_format":        get_setting('kiosk_clock_format', '12'),
         "timezone":            get_setting('kiosk_timezone', 'UTC'),
         "map_pin_duration_min": int(get_setting('kiosk_map_pin_duration_min', '60') or 60),
+        "chat_retention_hours": int(get_setting('kiosk_chat_retention_hours', str(CHAT_RETENTION_HOURS))
+                                     or CHAT_RETENTION_HOURS),
         # Public like the rest of this endpoint — a callsign is a public
         # amateur-radio identifier by regulation, not a secret (same posture
         # as the club/author callsigns already named in this project).
@@ -5676,6 +5683,14 @@ def api_kiosk_settings_put():
             set_setting('kiosk_map_pin_duration_min', str(val))
         except (TypeError, ValueError):
             return jsonify({"error": "map_pin_duration_min must be an integer"}), 400
+    if "chat_retention_hours" in data:
+        try:
+            val = int(data["chat_retention_hours"])
+            if not (1 <= val <= 720):
+                return jsonify({"error": "chat_retention_hours must be 1–720 hours (30 days)"}), 400
+            set_setting('kiosk_chat_retention_hours', str(val))
+        except (TypeError, ValueError):
+            return jsonify({"error": "chat_retention_hours must be an integer"}), 400
     if "aprs_is_callsign" in data:
         callsign = str(data["aprs_is_callsign"]).strip().upper()
         if callsign and not APRS_CALLSIGN_RE.match(callsign):
@@ -8900,12 +8915,14 @@ def api_chat_messages_delete(mid):
 
 
 def _chat_janitor_sweep(db, now):
-    """One prune pass: age-based (CHAT_RETENTION_HOURS) plus a hard row cap
-    (CHAT_LOG_MAX_ROWS, oldest first) — mirrors _nws_prune_expired_locally()'s
-    shape (a standalone db/now-taking function the loop calls each cycle, so
-    it's directly testable against a real sqlite fixture without touching
-    threading). No per-user/global byte-cap logic like recordings needs —
-    chat rows are small and uniform, a plain row-count cap is enough.
+    """One prune pass: age-based (owner-configurable retention, Kiosk
+    Settings' 'kiosk_chat_retention_hours' -- CHAT_RETENTION_HOURS is only
+    the seeded default) plus a hard row cap (CHAT_LOG_MAX_ROWS, oldest
+    first) — mirrors _nws_prune_expired_locally()'s shape (a standalone
+    db/now-taking function the loop calls each cycle, so it's directly
+    testable against a real sqlite fixture without touching threading). No
+    per-user/global byte-cap logic like recordings needs — chat rows are
+    small and uniform, a plain row-count cap is enough.
     Returns (aged_count, over_cap_count).
 
     `now` must represent UTC (e.g. datetime.now(timezone.utc)) — created_at
@@ -8913,7 +8930,9 @@ def _chat_janitor_sweep(db, now):
     plain string comparison against it with no timezone conversion of its
     own. The caller is responsible for that, same reasoning as
     _chat_row_to_dict()'s UTC tagging."""
-    cutoff = (now - timedelta(hours=CHAT_RETENTION_HOURS)).strftime('%Y-%m-%d %H:%M:%S')
+    retention_hours = int(get_setting('kiosk_chat_retention_hours', str(CHAT_RETENTION_HOURS))
+                          or CHAT_RETENTION_HOURS)
+    cutoff = (now - timedelta(hours=retention_hours)).strftime('%Y-%m-%d %H:%M:%S')
     aged = db.execute("DELETE FROM chat_messages WHERE created_at < ?", (cutoff,))
     total = db.execute("SELECT COUNT(*) AS c FROM chat_messages").fetchone()['c']
     over_cap = 0

--- a/templates/henwen-manager.html
+++ b/templates/henwen-manager.html
@@ -1396,6 +1396,17 @@ pre.codeblock { background: var(--bg3); padding: 12px; border-radius: 4px; font-
             </span>
           </div>
         </div>
+        <div class="form-group" style="margin-top:16px">
+          <label class="form-label">Chat Message Retention (hours)</label>
+          <div style="display:flex;gap:8px;align-items:center">
+            <input type="number" id="ks-chat-retention" class="form-control" style="width:90px"
+                   min="1" max="720" value="24">
+            <span style="font-size:0.82rem;color:var(--text-muted)">
+              How long kiosk Chat panel messages are kept before being auto-deleted (1–720 hours,
+              i.e. up to 30 days). A hard cap of 5000 messages also applies regardless of age.
+            </span>
+          </div>
+        </div>
         <div class="form-group" style="margin-top:24px;padding-top:16px;border-top:1px solid var(--border)">
           <div style="font-weight:600;margin-bottom:8px">APRS-IS (Network Map)</div>
           <label class="form-label">APRS-IS Callsign</label>
@@ -5894,6 +5905,8 @@ async function ksLoad() {
   ksPopulateTZ(d.timezone || 'UTC');
   var pinInp = document.getElementById('ks-pin-min');
   if (pinInp) pinInp.value = d.map_pin_duration_min || 60;
+  var chatRetInp = document.getElementById('ks-chat-retention');
+  if (chatRetInp) chatRetInp.value = d.chat_retention_hours || 24;
   var aprsInp = document.getElementById('ks-aprs-callsign');
   if (aprsInp) aprsInp.value = d.aprs_is_callsign || '';
   var aprsMaxInp = document.getElementById('ks-aprs-max-stations');
@@ -5959,6 +5972,11 @@ async function ksSave() {
   if (isNaN(pinMin) || pinMin < 1 || pinMin > 480) {
     st.textContent = 'Map pin duration must be 1–480 minutes.'; st.style.color = 'var(--danger)'; return;
   }
+  var chatRetInp = document.getElementById('ks-chat-retention');
+  var chatRet    = chatRetInp ? parseInt(chatRetInp.value, 10) : 24;
+  if (isNaN(chatRet) || chatRet < 1 || chatRet > 720) {
+    st.textContent = 'Chat retention must be 1–720 hours.'; st.style.color = 'var(--danger)'; return;
+  }
   var aprsInp      = document.getElementById('ks-aprs-callsign');
   var aprsCallsign = aprsInp ? aprsInp.value.trim().toUpperCase() : '';
   if (aprsCallsign && !/^[A-Z0-9]{3,9}(-[A-Z0-9]{1,2})?$/.test(aprsCallsign)) {
@@ -5975,6 +5993,7 @@ async function ksSave() {
     clock_format:         fmtEl ? fmtEl.value : '12',
     timezone:             tzEl  ? tzEl.value  : 'UTC',
     map_pin_duration_min: pinMin,
+    chat_retention_hours: chatRet,
     aprs_is_callsign:     aprsCallsign,
     aprs_max_stations:    aprsMax,
   };

--- a/tests/test_chat_routes.py
+++ b/tests/test_chat_routes.py
@@ -305,3 +305,55 @@ class TestChatJanitorSweep:
 
         assert captured['now'].tzinfo is not None
         assert captured['now'].utcoffset() == timedelta(0)
+
+
+class TestChatRetentionSetting:
+    """Chat retention time is an owner-facing Kiosk Setting
+    ('kiosk_chat_retention_hours') rather than the fixed CHAT_RETENTION_HOURS
+    it used to be -- see api_kiosk_settings_get/put() and
+    _chat_janitor_sweep()'s use of get_setting(). CHAT_RETENTION_HOURS is
+    now only the seeded default for a fresh install."""
+
+    def test_default_matches_seeded_constant(self, client, create_user):
+        create_user("owner1", role="owner")
+        resp = client.get("/api/kiosk/settings")
+        assert resp.status_code == 200
+        assert resp.get_json()["chat_retention_hours"] == app.CHAT_RETENTION_HOURS
+
+    def test_owner_can_change_it_and_it_round_trips(self, client, create_user):
+        create_user("owner1", role="owner")
+        _login(client, "owner1")
+        put_resp = client.put("/api/kiosk/settings", json={"chat_retention_hours": 72})
+        assert put_resp.status_code == 200
+        get_resp = client.get("/api/kiosk/settings")
+        assert get_resp.get_json()["chat_retention_hours"] == 72
+
+    def test_rejects_out_of_range(self, client, create_user):
+        create_user("owner1", role="owner")
+        _login(client, "owner1")
+        too_low  = client.put("/api/kiosk/settings", json={"chat_retention_hours": 0})
+        too_high = client.put("/api/kiosk/settings", json={"chat_retention_hours": 721})
+        assert too_low.status_code == 400
+        assert too_high.status_code == 400
+
+    def test_rejects_non_integer(self, client, create_user):
+        create_user("owner1", role="owner")
+        _login(client, "owner1")
+        resp = client.put("/api/kiosk/settings", json={"chat_retention_hours": "lots"})
+        assert resp.status_code == 400
+
+    def test_janitor_sweep_honors_a_shorter_configured_retention(self, client, create_user):
+        create_user("owner1", role="owner")
+        app.set_setting('kiosk_chat_retention_hours', '1')
+        db = app.get_db()
+        now_utc = datetime.now(timezone.utc)
+        # 2 hours old: still within the seeded 24h default, but past a 1h override.
+        old_ts = (now_utc - timedelta(hours=2)).strftime('%Y-%m-%d %H:%M:%S')
+        recent_id = _insert_message(db, message="recent", created_at=now_utc.strftime('%Y-%m-%d %H:%M:%S'))
+        _insert_message(db, message="old", created_at=old_ts)
+
+        aged, over_cap = app._chat_janitor_sweep(db, now_utc)
+        assert aged == 1
+        assert over_cap == 0
+        remaining = db.execute("SELECT id FROM chat_messages").fetchall()
+        assert [r["id"] for r in remaining] == [recent_id]


### PR DESCRIPTION
## Summary
Closes #19. Chat retention was a fixed `CHAT_RETENTION_HOURS` constant (24h); it's now `kiosk_chat_retention_hours` in Manager > Kiosk Settings (1–720 hours), following the same settings-table pattern as idle timeout / clock format / map pin duration. Message length and the hard 5000-row cap stay fixed — only retention time was in scope.

## Test plan
- [x] Full test suite passes (460 tests, 5 new in `tests/test_chat_routes.py`)
- [x] Verified in a real browser against an isolated dev instance: field loads, saves, round-trips through a reload, and rejects out-of-range values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgHFiuW5xSrdaVEe6eQMKj