### PR TITLE
Record which user initiated each connection in Connection History

### DIFF
--- a/app.py
+++ b/app.py
@@ -691,8 +691,19 @@ def get_db():
         direction         TEXT    DEFAULT '',
         connected_at      REAL    NOT NULL,
         disconnected_at   REAL,
-        duration_seconds  REAL
+        duration_seconds  REAL,
+        initiated_by      TEXT    DEFAULT ''
     )""")
+    # initiated_by: the HenWen username that clicked Connect/Perm Connect (looked
+    # up from _kiosk_temp_conns at the moment the AMI poller observes the link
+    # come up — see _db_conn_open()). Blank for anything HenWen didn't initiate
+    # itself: a link made permanent in rpt.conf directly, a raw AMI/CLI ilink
+    # command, or app_rpt auto-reconnecting a dropped ilink 13 after HenWen's
+    # own in-process _kiosk_temp_conns entry for it was lost to a restart.
+    # "Smart Connector" for connections the scheduler made on its own.
+    _connhist_cols = {r[1] for r in conn.execute("PRAGMA table_info(connection_history)").fetchall()}
+    if 'initiated_by' not in _connhist_cols:
+        conn.execute("ALTER TABLE connection_history ADD COLUMN initiated_by TEXT DEFAULT ''")
     # _db_conn_open()/_db_conn_close() (called from the 1s AMI poll loop, on
     # every connect/disconnect) both filter on (local_node, peer_node,
     # disconnected_at) -- unlike permanent_links/kiosk_temp_conns, which use
@@ -2590,8 +2601,10 @@ def _poll_loop():
             # individually best-effort (they catch and log their own errors).
             for (ln, pn, direction) in _conn_opens:
                 info = lookup_node(pn)   # may hit the network on a cache miss
+                with _kiosk_temp_lock:
+                    initiated_by = _kiosk_temp_conns.get((ln, pn), {}).get('initiated_by', '')
                 _db_conn_open(ln, pn, info.get("callsign", ""),
-                              info.get("location", ""), direction)
+                              info.get("location", ""), direction, initiated_by)
             for (ln, pn) in _conn_closes:
                 _db_conn_close(ln, pn)
             for (ln, pn) in _link_prunes:
@@ -2909,7 +2922,7 @@ def _forget_keyed(node: str):
 
 # ── Connection history DB helpers ──────────────────────────────────────────────
 
-def _db_conn_open(local_node, peer, callsign, location, direction):
+def _db_conn_open(local_node, peer, callsign, location, direction, initiated_by=''):
     """Insert a connection record only if none is already open for this pair."""
     try:
         db = get_db()
@@ -2922,9 +2935,9 @@ def _db_conn_open(local_node, peer, callsign, location, direction):
             return
         db.execute(
             "INSERT INTO connection_history "
-            "(local_node, peer_node, peer_callsign, peer_location, direction, connected_at) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
-            (local_node, peer, callsign, location, direction, time.time())
+            "(local_node, peer_node, peer_callsign, peer_location, direction, connected_at, initiated_by) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (local_node, peer, callsign, location, direction, time.time(), initiated_by)
         )
         db.commit()
         log("DEBUG", f"[CONNHIST] Opened: {local_node} <-> {peer} ({direction})")
@@ -5788,9 +5801,9 @@ def api_conn_history():
         where.append("local_node = ?")
         params.append(node)
     if search:
-        where.append("(peer_node LIKE ? OR peer_callsign LIKE ? OR peer_location LIKE ?)")
+        where.append("(peer_node LIKE ? OR peer_callsign LIKE ? OR peer_location LIKE ? OR initiated_by LIKE ?)")
         pat = "%" + search + "%"
-        params.extend([pat, pat, pat])
+        params.extend([pat, pat, pat, pat])
     where_sql = ("WHERE " + " AND ".join(where)) if where else ""
 
     total = db.execute(
@@ -6718,7 +6731,17 @@ def api_ami_connect():
         }
 
     try:
-        return jsonify(ami_send_command(_do))
+        result = ami_send_command(_do)
+        if result.get("success") and mode in ("2", "3", "12", "13"):
+            # Attribute this connection to the logged-in user for Connection
+            # History (see _db_conn_open()), without disturbing any Permanent/
+            # Idle-timeout tracking an earlier connect on this pair already set
+            # in _kiosk_temp_conns — this raw ilink panel doesn't manage that
+            # state itself, unlike /api/status/connect and /api/ami/perm_connect.
+            with _kiosk_temp_lock:
+                entry = _kiosk_temp_conns.setdefault((local_node, remote_node), {})
+                entry['initiated_by'] = session.get('username', '')
+        return jsonify(result)
     except Exception as e:
         log("ERROR", f"[API] /api/ami/connect error: {e}")
         return jsonify({"error": str(e)}), 500
@@ -6780,6 +6803,12 @@ def api_ami_perm_connect():
 
     try:
         result = ami_send_command(_do)
+        if result.get("success") and mode in ("2", "3"):
+            # Non-permanent connect modes via this panel: attribute only,
+            # same as /api/ami/connect — see the comment there.
+            with _kiosk_temp_lock:
+                entry = _kiosk_temp_conns.setdefault((local_node, remote_node), {})
+                entry['initiated_by'] = session.get('username', '')
         if result.get("success") and mode in ("12", "13"):
             monitor = (mode == "12")
             with _kiosk_temp_lock:
@@ -6788,6 +6817,7 @@ def api_ami_perm_connect():
                     'monitor':     monitor,
                     'no_timeout':  False,
                     'last_active': time.time(),
+                    'initiated_by': session.get('username', ''),
                 }
             db = get_db()
             db.execute(
@@ -7170,10 +7200,11 @@ def api_status_connect():
         now = time.time()
         with _kiosk_temp_lock:
             _kiosk_temp_conns[(local_node, remote_node)] = {
-                'permanent':   permanent,
-                'monitor':     monitor,
-                'no_timeout':  False,
-                'last_active': now,
+                'permanent':    permanent,
+                'monitor':      monitor,
+                'no_timeout':   False,
+                'last_active':  now,
+                'initiated_by': session.get('username', ''),
             }
         if permanent:
             db = get_db()
@@ -12682,6 +12713,12 @@ def _run_connectors():
                         raise RuntimeError(
                             f"ilink 3 rejected by Asterisk: {result.get('raw', '')[:120]}"
                         )
+                    # Attribute this connection to Smart Connector for Connection
+                    # History (see _db_conn_open()) — this is a scheduled connect,
+                    # not a specific logged-in user's action.
+                    with _kiosk_temp_lock:
+                        entry = _kiosk_temp_conns.setdefault((local, target), {})
+                        entry['initiated_by'] = 'Smart Connector'
                     db.execute(
                         "UPDATE connectors SET state='connected', state_msg='Connected', "
                         "state_updated=?, connected_at=?, last_activity=?"

--- a/templates/henwen-manager.html
+++ b/templates/henwen-manager.html
@@ -1108,7 +1108,7 @@ pre.codeblock { background: var(--bg3); padding: 12px; border-radius: 4px; font-
       <div class="card-header">
         <h2>History</h2>
         <div class="btn-row">
-          <input id="ch-search" type="search" placeholder="Search peer / callsign…" style="width:180px;font-size:0.82rem;padding:3px 7px;border:1px solid var(--border);border-radius:4px;background:var(--bg3);color:var(--text)" oninput="chLoad(0)">
+          <input id="ch-search" type="search" placeholder="Search peer / callsign / user…" style="width:180px;font-size:0.82rem;padding:3px 7px;border:1px solid var(--border);border-radius:4px;background:var(--bg3);color:var(--text)" oninput="chLoad(0)">
           <select id="ch-node-sel" onchange="chLoad(0)" style="font-size:0.82rem;padding:3px 6px;border:1px solid var(--border);border-radius:4px;background:var(--bg3);color:var(--text)">
             <option value="">All nodes</option>
             {% for node in nodes %}<option value="{{ node }}">{{ node }}</option>{% endfor %}
@@ -1119,8 +1119,8 @@ pre.codeblock { background: var(--bg3); padding: 12px; border-radius: 4px; font-
       </div>
       <div class="card-body" style="padding:0">
         <table class="tbl" id="ch-table">
-          <thead><tr><th>Connected</th><th>Peer Node</th><th>Callsign</th><th>Location</th><th>Dir</th><th>Duration / Status</th></tr></thead>
-          <tbody id="ch-tbody"><tr><td colspan="6" class="muted" style="padding:14px">Loading…</td></tr></tbody>
+          <thead><tr><th>Connected</th><th>Peer Node</th><th>Callsign</th><th>Location</th><th>Dir</th><th>By</th><th>Duration / Status</th></tr></thead>
+          <tbody id="ch-tbody"><tr><td colspan="7" class="muted" style="padding:14px">Loading…</td></tr></tbody>
         </table>
       </div>
       <div class="card-body" style="border-top:1px solid var(--border);padding:8px 12px;display:flex;gap:12px;align-items:center">
@@ -4256,11 +4256,11 @@ async function chLoad(offset) {
   if (node)   url += '&node='   + encodeURIComponent(node);
   var r = await api(url);
   var tbody = document.getElementById('ch-tbody');
-  if (!r.ok) { tbody.innerHTML = '<tr><td colspan="6" class="muted" style="padding:14px">Error loading history.</td></tr>'; return; }
+  if (!r.ok) { tbody.innerHTML = '<tr><td colspan="7" class="muted" style="padding:14px">Error loading history.</td></tr>'; return; }
   _chTotal = r.data.total;
   var rows = r.data.rows;
   if (!rows.length) {
-    tbody.innerHTML = '<tr><td colspan="6" class="muted" style="padding:14px">No records found.</td></tr>';
+    tbody.innerHTML = '<tr><td colspan="7" class="muted" style="padding:14px">No records found.</td></tr>';
   } else {
     var html = '';
     rows.forEach(function(row) {
@@ -4274,6 +4274,7 @@ async function chLoad(offset) {
         + '<td style="font-size:0.85rem">'                     + esc(row.peer_callsign || '—') + '</td>'
         + '<td style="font-size:0.82rem;color:var(--text2)">'  + esc(row.peer_location || '—') + '</td>'
         + '<td style="font-size:0.8rem;color:var(--text2)">'   + esc(dirLabel) + '</td>'
+        + '<td style="font-size:0.82rem;color:var(--text2)">'  + esc(row.initiated_by || '—') + '</td>'
         + '<td>' + status + '</td>'
         + '</tr>';
     });


### PR DESCRIPTION
## Summary
- Adds an `initiated_by` column to `connection_history`, populated with the logged-in username at the moment the AMI poller observes the link come up (looked up from `_kiosk_temp_conns`, which is where the username gets stashed when `/api/status/connect`, `/api/ami/connect`, or `/api/ami/perm_connect` fires the `ilink` command).
- Smart Connector's own scheduled connects are tagged `"Smart Connector"` rather than a blank/user field, so scheduled vs. human-initiated links stay distinguishable.
- Links HenWen didn't initiate itself (a static `rpt.conf` `connect=`, a raw AMI/CLI `ilink`, or app_rpt auto-reconnecting a dropped permanent link after a restart wiped in-process state) stay blank — same posture as the existing Permanent/Idle-timeout tracking.
- Manager > Connection History gets a new "By" column, and the search box now also matches on `initiated_by`.

## Test plan
- [x] `./venv/bin/pytest` — 460 passed
- [x] `python3 -m py_compile app.py`
- [ ] Manual: connect a node from the Status Board as a couple of different accounts, confirm the right username shows up in Manager > Connection History; trigger a Smart Connector scheduled connect and confirm it shows "Smart Connector"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GPgxBagLmVecSDfqG1rhp