### PR TITLE
CHANGELOG: add Unreleased entry for connection-history initiated_by

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **Added: Connection History now records which user initiated each connection.** A new "By" column on Manager > Connection History shows the logged-in username that clicked Connect (or "Smart Connector" for a scheduled connect); also included in the panel's search. A link HenWen didn't initiate itself — a static `rpt.conf` `connect=`, a raw AMI/CLI `ilink`, or app_rpt auto-reconnecting a permanent link after a restart — is shown blank, same as the existing Permanent/Idle-timeout tracking.
+
 ## v2026.08.30
 
 - **Added: optional TOTP two-factor authentication**, self-service for every account role from Manager > Settings or a new Status Board "Account" popup (the latter also gives plain `user`/kiosk accounts a way to change their own password for the first time, which they previously had no way to do). Ten single-use recovery codes are shown once at enrollment; admin+ can force-reset (never view or set) another account's 2FA for lost-device recovery.


### PR DESCRIPTION
## Summary
- Adds an "Unreleased" section to CHANGELOG.md documenting the Connection History `initiated_by` feature merged in #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GPgxBagLmVecSDfqG1rhp