### PR TITLE
Hide the "or hold Space" PTT hint on mobile

### DIFF
--- a/templates/status.html
+++ b/templates/status.html
@@ -797,6 +797,10 @@ html, body { height: 100%; background: var(--bg); color: var(--text);
   .header-actions { gap: 6px; }
   .header-club-logo { display: none; }
 
+  /* No physical keyboard on mobile, so the Space-bar PTT shortcut hint is
+     just noise on a touch device (the button itself is still the PTT). */
+  .tx-ptt-space-hint { display: none; }
+
   /* Header hamburger (issue #35): everything except Login folds into one
      menu instead of a scrollable icon strip. #header-menu-items keeps
      display:contents' desktop flow above; here it becomes the actual
@@ -1217,7 +1221,7 @@ html, body { height: 100%; background: var(--bg); color: var(--text);
         </span>
       </div>
       <div id="tx-bar" style="display:none">
-        <button id="tx-ptt" disabled><svg class="icon"><use href="#icon-mic"></use></svg> PTT &mdash; hold to transmit&ensp;<span style="font-size:0.7rem;font-weight:400">(or hold Space &middot; keys in ~&frac12;s)</span></button>
+        <button id="tx-ptt" disabled><svg class="icon"><use href="#icon-mic"></use></svg> PTT &mdash; hold to transmit&ensp;<span class="tx-ptt-space-hint" style="font-size:0.7rem;font-weight:400">(or hold Space &middot; keys in ~&frac12;s)</span></button>
         <div id="tx-audio-row">
           <span style="font-size:0.7rem;color:var(--text2);flex-shrink:0">Mic</span>
           <div id="tx-meter"><div id="tx-meter-fill"></div></div>


### PR DESCRIPTION
## Summary
- The PTT button's "(or hold Space · keys in ~½s)" hint is desktop-only info (no physical keyboard on a touch device) — hidden via a mobile media-query rule, same pattern as the other mobile-only text/element toggles.
- The PTT button itself is unaffected on mobile; only the hint span is hidden.

## Test plan
- [x] Full pytest suite (460 passed)
- [ ] Owner to confirm on mobile: PTT button shows without the Space hint, still works to transmit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GPgxBagLmVecSDfqG1rhp