### PR TITLE
Remove the experimental Bluetooth PTT checkbox

### DIFF
--- a/templates/status.html
+++ b/templates/status.html
@@ -1299,11 +1299,6 @@ html, body { height: 100%; background: var(--bg); color: var(--text);
           <input type="range" id="tx-gain" min="0" max="200" value="100" title="Microphone gain">
           <span id="tx-gain-val" style="font-size:0.7rem;color:var(--text2);width:3em;flex-shrink:0">100%</span>
         </div>
-        <label style="display:flex;align-items:center;gap:6px;font-size:0.72rem;color:var(--text2);padding:4px 0 0"
-               title="Uses a paired Bluetooth headset/PTT button's play/pause control to toggle transmit. Experimental: exact behavior depends on your specific device and phone, so test it before relying on it.">
-          <input type="checkbox" id="tx-bt-ptt">
-          Bluetooth PTT button (experimental) &mdash; toggles TX on press
-        </label>
         <div id="tx-status" style="font-size:0.75rem;color:var(--accent);min-height:1em"></div>
       </div>
       <div class="connector-warn-bar" id="connector-warn-bar" style="display:none">
@@ -5755,7 +5750,6 @@ async function armTx() {
         /* Listen is the monitor path — make sure it's running */
         if (!_listenActive) _startListen();
         _txTouchIdle();
-        _txBtSync();
         _txDiag('armed', 'call confirmed');
         _txStatsSample('armed');
       });
@@ -5803,7 +5797,6 @@ function _txTeardown() {
   _txUnkey();
   clearTimeout(_tx.idleTimer);
   clearTimeout(_tx.statsTimer);
-  _txBtSync();
   var pttEl = document.getElementById('tx-ptt');
   if (pttEl) pttEl.disabled = true;
   if (_tx.session) { try { _tx.session.terminate(); } catch (e) {} _tx.session = null; }
@@ -5867,40 +5860,6 @@ function _txUnkey() {
   }
 }
 
-/* ── Bluetooth/hardware PTT button (experimental) ────────────────────────
-   Cheap Bluetooth "PTT" buttons sold for radio apps (including Tidradio's)
-   advertise working with "most PTT applications" with no per-app pairing
-   step — that's only possible if the button rides the standard Bluetooth
-   headset control (AVRCP play/pause, the same signal a wired headset's
-   inline button sends) rather than a proprietary protocol each app has to
-   support individually. That's the hook used here, via the Media Session
-   API: while armed and this box is checked, a 'play' or 'pause' media
-   action toggles TX. Toggle rather than press/hold because the OS/browser
-   only ever hands a page a single semantic action, not a raw button-down/
-   button-up pair with real timing.
-   This was implemented without the actual hardware in hand to verify
-   against, so it's opt-in and off by default — a device that behaves
-   differently (or a phone that never routes the button to the page at
-   all) should be inert, not surprising. Confirm the toggle behavior
-   before relying on it in the field. */
-function _txBtSavedPref() {
-  return localStorage.getItem('henwen-tx-bt-ptt') === '1';
-}
-function _txBtToggle() {
-  if (!_tx.armed || !_tx.session || !_tx.session.isEstablished()) return;
-  if (_tx.keyed) _txUnkey(); else _txKey();
-  _txDiag('bt-toggle', 'keyed=' + _tx.keyed);
-}
-function _txBtSync() {
-  if (!('mediaSession' in navigator)) return;
-  var want = _tx.armed && _txBtSavedPref();
-  try {
-    navigator.mediaSession.setActionHandler('play',  want ? _txBtToggle : null);
-    navigator.mediaSession.setActionHandler('pause', want ? _txBtToggle : null);
-    navigator.mediaSession.playbackState = want ? 'playing' : 'none';
-  } catch (e) { _txDiag('bt-handler-err', e.message); }
-}
-
 (function() {
   var gain = document.getElementById('tx-gain');
   var gval = document.getElementById('tx-gain-val');
@@ -5911,15 +5870,6 @@ function _txBtSync() {
     localStorage.setItem('henwen-tx-gain', gain.value);
     if (_tx.gainNode) _tx.gainNode.gain.value = gain.value / 100;
   });
-
-  var btChk = document.getElementById('tx-bt-ptt');
-  if (btChk) {
-    btChk.checked = _txBtSavedPref();
-    btChk.addEventListener('change', function() {
-      localStorage.setItem('henwen-tx-bt-ptt', btChk.checked ? '1' : '0');
-      _txBtSync();
-    });
-  }
 
   var ptt = document.getElementById('tx-ptt');
   ptt.addEventListener('pointerdown',   function(e) { e.preventDefault(); _txKey(); });


### PR DESCRIPTION
The "Bluetooth PTT button (experimental)" checkbox in the TX bar cannot work, and should not stay in the UI where an operator can turn it on and rely on it.

## Why it can't work

It shipped in 2d374a3 on a reasonable theory: vendors advertise these buttons as working with "most PTT applications" with no per-app pairing step, which is only possible if the button rides the standard AVRCP play/pause control. It was written without the hardware in hand, opt-in and off by default, with a note to confirm the behaviour in the field.

Testing against a real Tidradio TD-Q2L disproved the theory. **The PTT-labelled button emits no standard signal at all** — confirmed by registering all 15 Media Session actions plus DOM `keydown`/`keyup` and the Gamepad API, in a run where the mic's *other* buttons (Power, Fwd, Rev) logged correctly seconds apart as a live control. The button's state is only reachable over a proprietary BLE GATT characteristic.

## Why removing rather than leaving it

Beyond not working, it's a **toggle** — press to key, press again to unkey — because a media key is a single semantic action with no down/up pair. On a repeater that means a plausible path to a latched transmitter. That was an acceptable trade when the feature was expected to work; it isn't one now that it can't.

## Scope

Removes the checkbox, its three functions (`_txBtSavedPref`, `_txBtToggle`, `_txBtSync`), its two call sites, and its `localStorage` key. 50 deletions, no additions. The on-screen PTT button and the Space key are untouched and remain true press-and-hold.

460 tests pass. The full device investigation lives on the `ble-ptt-button` branch (#56) and is not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GPgxBagLmVecSDfqG1rhp