### PR TITLE
Add TX mic diagnostics; file the TD-Q2L research under docs/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,21 @@ The login callsign (`aprs_is_callsign`) is a Manager > Kiosk Settings field (`/a
 
 The frontend's radius slider (1-200mi, default 25) and on/off state are plain `localStorage` prefs, same pattern as the Radar/tile-style toggles; a thin circle outline on the map traces the selected radius around the resolved center. Markers render as a small purple circle (`makeAprsIcon()`), deliberately not the teardrop node-pin or gold hosted-node star, fading with age the same way the global-activity pins do (`aprsPinStyle()`, mirroring `globalPinStyle()`), and live in their own `_aprsMarkers` array on a separate 5-minute poll timer (`APRS_POLL_MS`) so they're untouched by `updateMap()`'s much more frequent node/activity marker rebuild.
 
+### Hardware notes (`docs/`)
+
+`docs/td-q2l/` holds the reverse-engineering record for a Tidradio TD-Q2L
+Bluetooth PTT mic, plus a standalone Web Bluetooth test harness. **The
+integration was attempted and abandoned** — no TD-Q2L code remains in the
+app. Read it before attempting any Bluetooth PTT accessory: it documents
+that the mic's PTT button emits no signal reachable by a web page (verified
+against all 15 Media Session actions, DOM key events and the Gamepad API,
+with a live control), that its proprietary BLE characteristic goes silent
+whenever Bluetooth audio is in use, and that a native Android app does not
+help either — nRF Connect, which already calls `requestConnectionPriority()`,
+receives nothing during a call, placing the conflict in the Bluetooth
+controller's scheduling of one shared radio. Several conclusions in that file
+were reached and later overturned; the sequence is left visible on purpose.
+
 ### Templates
 
 - `templates/status.html` — kiosk/status board (`/` and `/status` routes); self-contained SPA with embedded JS (~1800 lines). Contains the live audio player, network map, weather bar, and global activity feed. Accessible without login.

--- a/docs/td-q2l/TD-Q2L-test.html
+++ b/docs/td-q2l/TD-Q2L-test.html
@@ -1,0 +1,235 @@
+<!doctype html>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>TD-Q2L BLE PTT test harness</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font: 14px/1.5 system-ui, sans-serif; margin: 0; padding: 16px; max-width: 900px; }
+  h1 { font-size: 1.15rem; margin: 0 0 4px; }
+  p.sub { margin: 0 0 16px; opacity: .75; }
+  button { font: inherit; padding: 7px 12px; margin: 0 6px 6px 0; cursor: pointer; }
+  button:disabled { opacity: .4; cursor: not-allowed; }
+  #state { font-weight: 600; margin: 12px 0; }
+  #ptt { display: inline-block; min-width: 5.5em; text-align: center; padding: 3px 10px;
+         border-radius: 4px; background: #8883; }
+  #ptt.down { background: #d33; color: #fff; }
+  #log { white-space: pre-wrap; font-family: ui-monospace, monospace; font-size: 12px;
+         border: 1px solid #8886; border-radius: 4px; padding: 10px; height: 22em;
+         overflow-y: auto; margin-top: 12px; }
+  .hint { font-size: 12px; opacity: .75; border-left: 3px solid #8886; padding-left: 10px; }
+</style>
+
+<h1>TD-Q2L BLE PTT test harness</h1>
+<p class="sub">Standalone. No server-side anything — open it over <code>http://localhost</code> or HTTPS
+(Web Bluetooth needs a secure context; <code>file://</code> will not work).</p>
+
+<p class="hint">
+  From <code>docs/td-q2l/</code>: <code>python3 -m http.server 8000</code> then open
+  <code>http://localhost:8000/TD-Q2L-test.html</code> in Chrome.<br>
+  Only one central can hold the LE link — quit nRF Connect and close any HenWen tab first.
+</p>
+
+<div>
+  <button id="b-connect">1. Connect</button>
+  <button id="b-enum"    disabled>2. Enumerate services</button>
+  <button id="b-read"    disabled>3. Read once</button>
+  <button id="b-poll"    disabled>4. Start poll (150ms)</button>
+  <button id="b-notify"  disabled>5. Subscribe (notify)</button>
+  <button id="b-stop"    disabled>Stop</button>
+  <button id="b-clear">Clear log</button>
+</div>
+
+<div>
+  <button id="b-ffe0-read"   disabled>6. Read 0xFFE0 notify-char</button>
+  <button id="b-ffe0-notify" disabled>7. Subscribe 0xFFE0 notify-char</button>
+</div>
+
+<div id="state">Not connected &nbsp; PTT: <span id="ptt">—</span></div>
+<div id="log"></div>
+
+<script>
+const SERVICE = '89a8591d-bb19-485b-9f59-58492bc33e24';
+const CHAR    = '894c8042-e841-461c-a5c9-5a73d25db08e';
+/* Other services seen on this unit via nRF Connect. 0xFFE0 is very likely the
+   HM-10-style serial passthrough and is the main backup avenue if the PTT
+   characteristic stays unreadable. They must be declared here to be reachable
+   at all — Chrome blocks any service not named at requestDevice() time. */
+const EXTRA   = [0xFFE0, 0xFF00, 0xAE30];
+
+let device = null, server = null, chr = null, pollTimer = null;
+let ffe0Chr = null;
+let reads = 0, empties = 0, last = null;
+
+/* getPrimaryService() can race the platform's own GATT discovery on a device
+   with no cached attribute table: gatt.connect() resolves, and a NotFoundError
+   lands ~49ms later — far too fast for a real over-the-air discovery of a whole
+   attribute table to have completed and genuinely not found the service.
+   Retry rather than believe the first miss. */
+async function getPrimaryServiceRetry(uuid, tries = 6, delayMs = 500) {
+  let lastErr;
+  for (let i = 0; i < tries; i++) {
+    try { return await server.getPrimaryService(uuid); }
+    catch (e) {
+      lastErr = e;
+      if (e.name !== 'NotFoundError') throw e;
+      log(`getPrimaryService(${uuid.toString(16)}) miss ${i + 1}/${tries}, retrying in ${delayMs}ms`);
+      await new Promise(r => setTimeout(r, delayMs));
+    }
+  }
+  throw lastErr;
+}
+
+const $ = id => document.getElementById(id);
+function log(msg) {
+  const t = new Date().toISOString().slice(11, 23);
+  $('log').textContent += `${t}  ${msg}\n`;
+  $('log').scrollTop = $('log').scrollHeight;
+}
+function hex(dv) {
+  if (!dv || !dv.byteLength) return '(empty)';
+  return [...new Uint8Array(dv.buffer)].map(b => b.toString(16).padStart(2, '0')).join(' ');
+}
+function setPtt(down) {
+  if (down === last) return;
+  last = down;
+  $('ptt').textContent = down ? 'DOWN' : 'up';
+  $('ptt').className = down ? 'down' : '';
+  log(`>>> PTT ${down ? 'PRESSED' : 'RELEASED'}`);
+}
+function enable(ids, on) { ids.forEach(i => { $(i).disabled = !on; }); }
+
+$('b-clear').onclick = () => { $('log').textContent = ''; };
+
+$('b-connect').onclick = async () => {
+  try {
+    log('requestDevice() — pick TID-MIC-Q2L-…');
+    device = await navigator.bluetooth.requestDevice({
+      acceptAllDevices: true, optionalServices: [SERVICE, ...EXTRA],
+    });
+    log(`picked: ${device.name || '(unnamed)'}  id=${device.id}`);
+    device.addEventListener('gattserverdisconnected', () => {
+      log('!!! gattserverdisconnected');
+      $('state').firstChild.textContent = 'Disconnected ';
+      clearInterval(pollTimer);
+      ffe0Chr = null;
+    });
+    server = await device.gatt.connect();
+    log('gatt.connect() ok');
+    const svc = await getPrimaryServiceRetry(SERVICE);
+    log(`service ${SERVICE.slice(0, 8)}… ok`);
+    chr = await svc.getCharacteristic(CHAR);
+    const p = chr.properties;
+    log(`characteristic ok — properties: ${Object.keys(p).filter(k => p[k]).join(', ')}`);
+    $('state').firstChild.textContent = 'Connected ';
+    enable(['b-enum', 'b-read', 'b-poll', 'b-notify', 'b-stop', 'b-ffe0-read', 'b-ffe0-notify'], true);
+  } catch (e) { log(`ERROR ${e.name}: ${e.message}`); }
+};
+
+/* Backup avenue per TD-Q2L.md: 0xFFE0 is likely an HM-10-style serial
+   passthrough and may carry the same button state over a different
+   transport. Auto-picks its first notify-or-read characteristic since the
+   doc never sniffed 0xFFE1 specifically on this unit. */
+async function getFfe0Char() {
+  if (ffe0Chr) return ffe0Chr;
+  const svc = await getPrimaryServiceRetry(0xFFE0);
+  const cs = await svc.getCharacteristics();
+  const c = cs.find(c => c.properties.notify || c.properties.read) || cs[0];
+  if (!c) throw new Error('0xFFE0 has no characteristics');
+  log(`0xFFE0 using characteristic ${c.uuid} [${Object.keys(c.properties).filter(k => c.properties[k]).join(',')}]`);
+  ffe0Chr = c;
+  return c;
+}
+
+$('b-ffe0-read').onclick = async () => {
+  try {
+    const c = await getFfe0Char();
+    const v = await c.readValue();
+    log(`0xFFE0 read: byteLength=${v.byteLength} value=${hex(v)}`);
+  } catch (e) { log(`0xFFE0 read ERROR ${e.name}: ${e.message}`); }
+};
+
+$('b-ffe0-notify').onclick = async () => {
+  try {
+    const c = await getFfe0Char();
+    c.addEventListener('characteristicvaluechanged', e => {
+      const v = e.target.value;
+      log(`0xFFE0 notify: byteLength=${v.byteLength} value=${hex(v)}`);
+    });
+    await c.startNotifications();
+    log('0xFFE0 startNotifications() resolved. Press PTT.');
+  } catch (e) { log(`0xFFE0 notify ERROR ${e.name}: ${e.message}`); }
+};
+
+/* More than one characteristic under the same UUID, or properties differing
+   from what nRF Connect reports, would both explain a read that succeeds with
+   no bytes — and neither is visible through getCharacteristic() alone. */
+$('b-enum').onclick = async () => {
+  for (const uuid of [SERVICE, ...EXTRA]) {
+    try {
+      const svc = await getPrimaryServiceRetry(uuid);
+      const cs  = await svc.getCharacteristics();
+      log(`service ${uuid.toString(16)} — ${cs.length} characteristic(s):`);
+      for (const c of cs) {
+        const p = Object.keys(c.properties).filter(k => c.properties[k]).join(',');
+        log(`    ${c.uuid}  [${p}]`);
+      }
+    } catch (e) { log(`service ${uuid.toString(16)}: ${e.name} ${e.message}`); }
+  }
+};
+
+$('b-read').onclick = async () => {
+  try {
+    const v = await chr.readValue();
+    log(`read: byteLength=${v.byteLength} value=${hex(v)}`);
+    if (v.byteLength) setPtt(v.getUint8(0) === 1);
+  } catch (e) { log(`read ERROR ${e.name}: ${e.message}`); }
+};
+
+/* The whole question this harness exists to answer: does a plain read return
+   live button state on this platform? On Android Chrome it returns zero bytes
+   every time, while nRF Connect reads 0x01 from the same characteristic on the
+   same phone. Hold the button down while polling and watch byteLength. */
+$('b-poll').onclick = () => {
+  clearInterval(pollTimer);
+  reads = 0; empties = 0;
+  log('polling every 150ms — hold PTT down now');
+  pollTimer = setInterval(async () => {
+    try {
+      const v = await chr.readValue();
+      if (!v || !v.byteLength) {
+        empties++;
+        if (empties === 1 || empties % 40 === 0) log(`poll: EMPTY read #${empties}`);
+        return;
+      }
+      reads++;
+      if (reads === 1 || reads % 40 === 0) log(`poll: #${reads} value=${hex(v)}`);
+      setPtt(v.getUint8(0) === 1);
+    } catch (e) { log(`poll ERROR ${e.name}: ${e.message}`); }
+  }, 150);
+};
+
+$('b-notify').onclick = async () => {
+  try {
+    chr.addEventListener('characteristicvaluechanged', e => {
+      const v = e.target.value;
+      log(`notify: byteLength=${v.byteLength} value=${hex(v)}`);
+      if (v.byteLength) setPtt(v.getUint8(0) === 1);
+    });
+    await chr.startNotifications();
+    log('startNotifications() resolved — CCCD accepted. Press PTT.');
+  } catch (e) { log(`notify ERROR ${e.name}: ${e.message}`); }
+};
+
+$('b-stop').onclick = () => {
+  clearInterval(pollTimer);
+  try { chr && chr.stopNotifications(); } catch (e) {}
+  try { device && device.gatt.connected && device.gatt.disconnect(); } catch (e) {}
+  log('stopped / disconnected');
+};
+
+if (!navigator.bluetooth) {
+  log('This browser has no Web Bluetooth. Chrome/Edge on desktop or Android only.');
+} else {
+  log('Ready. Click Connect.');
+}
+</script>

--- a/docs/td-q2l/TD-Q2L.md
+++ b/docs/td-q2l/TD-Q2L.md
@@ -1,0 +1,755 @@
+# Tidradio TD-Q2L Bluetooth PTT mic — reverse-engineered notes
+
+> ## ABANDONED 2026-09-05 — no TD-Q2L code remains in HenWen
+>
+> The integration was dropped and every trace removed from
+> `templates/status.html`: the BLE/GATT client, the media-key PTT binding,
+> the input scanner, and the connection/keep-alive machinery. Browser TX is
+> back to the on-screen PTT button and the Space key, both of which are true
+> press-and-hold.
+>
+> **Why it was dropped.** The mic's PTT button emits no standard signal, so
+> the only route to it is a proprietary BLE characteristic — and that
+> characteristic goes silent the moment Bluetooth audio is in use, which is
+> the whole point of owning the mic. Binding transmit to the Rev media key
+> worked around the silence but could only ever be press-to-toggle, and a
+> latching transmitter is the wrong resting state for a repeater.
+>
+> **This file is kept as the record, not as a plan.** Everything below is
+> accurate and hard-won, including several conclusions that were reached and
+> later overturned — the sequence is left visible on purpose. Read it before
+> attempting this device, or a similar one, again.
+>
+> **The one thing that would change the answer:** an accessory with separate
+> BLE and Classic Bluetooth radios rather than a single combo chip. Every
+> software avenue is closed — including a native Android app, ruled out by
+> direct test rather than by argument (see the end of the settled section).
+>
+> `TD-Q2L-test.html` beside this file is a standalone Web Bluetooth harness,
+> independent of HenWen, if anyone wants to probe this or another unit.
+
+> **Status 2026-09-05 — settled. BLE PTT works, but not while the mic's own
+> audio is in use.**
+> The BLE link is solid once a fast connection interval is held: 19
+> consecutive clean press/release pairs on the phone, where every earlier
+> session got none. Web Bluetooth exposes no
+> `requestConnectionPriority()`, so the only lever a page has is sustained
+> GATT traffic — HenWen polls the characteristic every 40ms purely as a
+> keep-alive (the reads themselves return zero bytes on this device and are
+> discarded; **notifications** carry the button).
+> But delivery stops dead whenever TX is armed, which is when the classic
+> SCO audio link to the same headset comes up. Controlled test, poll rate
+> held constant: 11 pairs delivered idle, none armed, 3 pairs delivered idle
+> again. `0xFFE1` went silent at the same time, so it is the radio, not the
+> characteristic.
+> **Consequence:** since routing audio through the headset is the point of
+> owning it, the **Rev media key** is HenWen's transmit control — AVRCP rides
+> through an active SCO link where GATT does not. The cost is that Rev is a
+> toggle, not press-and-hold. The BLE path is kept for anyone not routing
+> audio to the Bluetooth device, and the TX bar now says plainly when a
+> connected PTT button will not respond.
+> A native Android app would not help: nRF Connect, which already uses
+> `requestConnectionPriority()`, receives nothing either while a call is
+> active — so this is the Bluetooth controller scheduling one shared radio,
+> below the application layer, not a Chrome or Web Bluetooth limitation.
+> See [Settled: BLE notifications and SCO audio cannot coexist](#settled-2026-09-05-ble-notifications-and-sco-audio-cannot-coexist).
+> Sections above it are kept as the working record — real data, several
+> superseded conclusions, including one retraction that was itself wrong.
+
+No public protocol documentation exists for this device (checked as of 2026-09).
+Tidradio markets it as compatible with "most PTT applications" without a
+per-app pairing step, which implied — before this was actually tested against
+real hardware — that it might ride standard Bluetooth media-remote commands.
+That turned out to be only half true: see below.
+
+## Buttons
+
+| Button | Behavior |
+|---|---|
+| Fwd (CH+) | Standard AVRCP media key — arrives as **`previoustrack`** (labelling is inverted vs. the media semantics). Long press is the mic's own Noise Reduction toggle, so it is not a free key. |
+| Rev (CH−) | Standard AVRCP media key — arrives as **`nexttrack`**. Not tied to any on-device function; the one genuinely free key. |
+| Volume + / − | Standard AVRCP media key — volume up/down |
+| Power (momentary press) | Standard AVRCP media key — play/pause (toggle) |
+| Power (long press) | Powers the mic off |
+| **PTT** | **Not a standard signal — exhaustively confirmed, see below.** Emits nothing any web page can observe. Only reachable via the device's proprietary BLE GATT characteristic below. |
+
+Everything except PTT is a real, OS-recognized hardware media key — any app
+using the standard media-key APIs (e.g. the Web `MediaSession` API in a
+browser) will see those presses with zero device-specific code.
+
+### The PTT button emits nothing observable — exhaustive scan, 2026-09-05
+
+Worth recording properly, because the first version of this claim rested on a
+scan that could not have found most of the possibilities: it registered only
+the Media Session `play`/`pause` actions, and a handler fires *only* for an
+action explicitly registered, so anything else the button might send was
+indistinguishable from silence.
+
+Re-run against every input surface a web page has:
+
+- **all 15 Media Session actions** — `play`, `pause`, `stop`, `seekbackward`,
+  `seekforward`, `seekto`, `skipad`, `previoustrack`, `nexttrack`,
+  `togglemicrophone`, `togglecamera`, `hangup`, `previousslide`, `nextslide`,
+  `enterpictureinpicture` (all accepted by Chrome on this phone)
+- **raw DOM `keydown`/`keyup`** on the window, capture phase
+- **the Gamepad API**, polled at 100ms
+
+Result — PTT pressed repeatedly, short and long, produced **zero events on
+every channel**. The same run captured, seconds apart:
+
+```
+16:57:28  scan-mediakey: pause          <- Power button
+16:57:30  scan-mediakey: previoustrack  <- Fwd
+16:57:31  scan-mediakey: nexttrack      <- Rev
+```
+
+That control matters: the channel was demonstrably live at the moment PTT
+was pressed. This is a real negative, not a null result from a broken test.
+
+Vol+/Vol- also produced nothing, as expected - those are absolute-volume
+commands the phone handles itself and never routes to a page.
+
+**Consequence:** hold-to-talk is unreachable through any standard API on this
+device. A media key is one semantic action with no down/up pair, so PTT bound
+to Rev is necessarily a toggle. The BLE characteristic below is the *only*
+path to genuine press-and-hold, since it alone reports live button state.
+
+The scan itself is kept in `status.html` behind `?btscan=1` (see
+`_txMediaKeyMode()`), so it can be re-run against a different accessory
+without rebuilding it.
+
+## The LE instance — full GATT service list
+
+The Q2L appears **twice** in Android's Bluetooth menu: the Classic BR/EDR
+instance (headset audio + AVRCP media keys) and a separate LE instance,
+`TID-MIC-Q2L-1a8d` / `29:D7:1F:9C:4E:58`. The LE one cannot be paired from
+Android's menu, and does not need to be — it reports **NOT BONDED** while
+fully connected and serving GATT. That is normal for a GATT-only peripheral;
+a failed pairing attempt there is not a fault and not worth chasing.
+
+Services, read off nRF Connect while connected (2026-09-05):
+
+| UUID | Notes |
+|---|---|
+| `0x1800` | Generic Access (standard) |
+| `0xAE30` | Vendor-specific, unexplored |
+| `0xFF00` | Vendor-specific, unexplored |
+| `89a8591d-bb19-485b-9f59-58492bc33e24` | **The PTT service.** Characteristic `894c8042-…` NOTIFY+READ, value `0x00` at rest, CCCD `0x2902` reads "Notifications enabled" |
+| `0xFFE0` | Almost certainly the HM-10-style BLE serial/UART passthrough (its `0xFFE1` characteristic is the usual notify/write pair). Unexplored, and the most promising backup if the PTT service proves unreliable |
+
+**No Human Interface Device service (`0x1812`).** This rules out the
+otherwise-attractive theory that bonding the LE instance would make the PTT
+button arrive as an ordinary BLE-HID keyboard key, giving OS-level
+press/release for free. It would not — there is no HID service to bond to,
+which is consistent with the exhaustive input scan above finding nothing on
+any standard channel.
+
+**Only one central can hold the LE link at a time.** nRF Connect and Chrome
+cannot both be connected, and whichever gets there first locks the other
+out — a likely cause of `Connection Error: Connection attempt failed.` in
+HenWen's log. Disconnect nRF Connect before testing the browser, and vice
+versa.
+
+## PTT button — BLE GATT protocol
+
+Sniffed with **nRF Connect for Mobile** (Nordic Semiconductor, free Android/iOS
+app): scan for the device, connect, browse GATT services for a non-standard
+128-bit UUID, find its Notify-capable characteristic, subscribe, then press
+the PTT button and watch the notified value.
+
+- **Service UUID:** `89a8591d-bb19-485b-9f59-58492bc33e24`
+- **Characteristic UUID:** `894c8042-e841-461c-a5c9-5a73d25db08e`
+- **Properties:** `NOTIFY`, `READ`
+- **Value:** a single byte reflecting *live* physical button state, not a
+  toggle/event — `0x01` while the button is physically held down, `0x00`
+  when released. This means a consumer gets true press/hold semantics for
+  free, not just "pressed" pulses.
+- **CCCD (`0x2902`):** must be written to enable notifications (standard BLE
+  "notifications enabled" descriptor) — any Web Bluetooth / GATT client
+  library's `startNotifications()`-equivalent call handles this.
+
+### Minimal Web Bluetooth consumer (JavaScript)
+
+```js
+const SERVICE_UUID = '89a8591d-bb19-485b-9f59-58492bc33e24';
+const CHAR_UUID    = '894c8042-e841-461c-a5c9-5a73d25db08e';
+
+/* Filtering requestDevice() by services only matches a device that
+   advertises that UUID in its BLE advertisement packet. This device's
+   custom PTT service is only visible AFTER connecting (that's how nRF
+   Connect found it) — it is not in the advertisement — so a services
+   filter here returns an empty picker every time, even with the mic right
+   next to the phone. acceptAllDevices + optionalServices is the fix: list
+   every nearby BLE device and grant access to the PTT service once
+   connected. */
+const device  = await navigator.bluetooth.requestDevice({ acceptAllDevices: true, optionalServices: [SERVICE_UUID] });
+const server  = await device.gatt.connect();
+const service = await server.getPrimaryService(SERVICE_UUID);
+const char    = await service.getCharacteristic(CHAR_UUID);
+
+char.addEventListener('characteristicvaluechanged', (e) => {
+  const pressed = e.target.value.getUint8(0) === 1;
+  // pressed === true  -> PTT physically held down
+  // pressed === false -> PTT released
+});
+await char.startNotifications();
+```
+
+Web Bluetooth is Chrome-only (Android + desktop) — no Safari/Firefox support,
+and it requires a secure context (HTTPS) plus a fresh user-gesture pairing
+each page load (no silent auto-reconnect on plain page load without also
+using the newer, less broadly supported `navigator.bluetooth.getDevices()`
+persistent-permission API).
+
+The device's BLE advertising also appears to only run in narrow windows
+(observed: sometimes visible right as the mic powers on or off, often
+invisible in between) rather than continuously — if the picker comes back
+empty, try clicking Connect at the moment of a power-cycle rather than
+assuming the mic is out of range or the code is wrong. Also check Android's
+own "Nearby devices" runtime permission for the browser (distinct from
+Location, on Android 12+) and, as a last resort, `chrome://bluetooth-internals`
+→ Devices → Start Scanning to confirm the browser's Bluetooth stack sees
+*any* device at all, independent of this page's code.
+
+## Audio routing gotcha (Chrome/WebRTC, not device-specific)
+
+The mic works as a real Bluetooth headset — verified with an actual cellular
+phone call, both directions of audio correctly routed through it while paired
+and connected, and separately confirmed the user's regular in-Chrome Zoom/
+Google Meet calls already use it fine with zero special handling. But a
+**web page's** plain `getUserMedia()` call did **not** automatically get the
+same routing in HenWen initially, even with the device already paired and
+shown as "Connected" in Android's Bluetooth settings.
+
+Root cause, confirmed empirically (not just theorized): HenWen's
+`getUserMedia()` call requested `autoGainControl: false` (turned off
+elsewhere to fix a clipping problem on a different mic). Chromium's Android
+audio backend appears to tie its automatic "route to whatever Bluetooth
+device is currently active" behavior to requesting the **full default**
+echoCancellation + noiseSuppression + autoGainControl trio — the same
+constraints Zoom/Meet request by default. Opting any one of them out seems
+to drop Chrome into a plain capture path that never engages Bluetooth SCO
+routing at all, regardless of what's paired/connected. Setting
+`autoGainControl: true` immediately fixed it — mic and speaker both
+confirmed working through the Tidradio with zero device-picker UI, exactly
+matching native call behavior.
+
+An earlier, now-abandoned approach tried working around this by manually
+enumerating devices (`navigator.mediaDevices.enumerateDevices()`, filtering
+`audioinput`/`audiooutput`, passing an explicit `deviceId` to `getUserMedia`
+and `audioElement.setSinkId()` for output) — this technically works as a
+fallback if the constraint-based fix ever stops applying, but it added a
+device-picker UI the actual fix made unnecessary. The constraint fix is
+simpler and matches how any other WebRTC site on this browser already
+behaves, so it's the one actually in use.
+
+## Radio contention between Bluetooth audio and BLE PTT — revised 2026-09-05
+
+An earlier revision of this file concluded that Bluetooth audio and the BLE
+PTT button were **mutually exclusive** on this device: that once a call was
+using the mic/speaker over classic Bluetooth, GATT notifications stopped
+arriving entirely, with `device.gatt.connected` still `true` and no
+disconnect event ever fired.
+
+**Field use contradicts that.** With the phone simply paired to the Q2L and
+Android routing mic and speaker to it as it does for any other app, the
+mic, the speaker and the BLE PTT button have all been observed working at
+the same time. So the mutual exclusion is not a fixed property of the
+device, and code should not be built around assuming it.
+
+What *is* real is intermittent contention. In one session the link connected
+four times, delivered zero press notifications, and dropped twice on its
+own after 14s and 39s. Two corrections to the original writeup fall out of
+that:
+
+- the drops raise a genuine `gattserverdisconnected`, where the original
+  writeup recorded none — which is what makes automatic reconnection
+  possible at all;
+- they happen with Bluetooth *capture* routing off too, so pinning it on
+  SCO capture specifically was wrong. Anything keeping the classic radio
+  busy is a candidate, including the board's own Listen playback going to
+  the headset over A2DP.
+
+Still unexplained: why the link sometimes delivers every press reliably and
+sometimes none at all, with no visible difference in configuration. The
+`tx-ble-connected` / `tx-ble-disconnected` / `tx-ble-value` trail in
+`journalctl -u HenWen` is there to pin that down — `tx-ble-connected` is
+logged only after `startNotifications()` resolves, so that line appearing
+without any `tx-ble-value` following it means the subscription was accepted
+and the notifications themselves are being lost.
+
+Not confirmed: whether a different (pricier / different chipset) Bluetooth
+PTT accessory would avoid this entirely, or whether some other combination
+of Android/Chrome versions handles the radio-sharing better.
+
+## Open problem: Chrome reads return zero bytes
+
+The BLE characteristic is the only route to genuine press-and-hold on this
+device (every standard input API was ruled out — see the exhaustive scan
+above). It works from nRF Connect and not from Chrome.
+
+**Confirmed working, Android + nRF Connect:**
+- connect to the LE instance (no bonding needed — it reports NOT BONDED while
+  fully serving GATT)
+- subscribe: pressing PTT flips the value `0x00` → `0x01` → `0x00`, every time
+- read while holding the button down: returns `0x01`
+
+**Confirmed failing, Android + Chrome (same phone, same device, same session):**
+- `requestDevice()` + `gatt.connect()` + `getPrimaryService()` +
+  `getCharacteristic()` all succeed
+- `startNotifications()` resolves — the CCCD write is accepted — and then
+  **no `characteristicvaluechanged` event ever fires** for a run of presses
+- `readValue()` resolves successfully but with a **zero-length DataView**, at
+  every one of ~7 reads/sec for minutes at a time
+
+### Ruled out, with the evidence
+
+| Theory | Killed by |
+|---|---|
+| The button emits some standard signal we never registered for | Exhaustive scan: all 15 Media Session actions, DOM `keydown`/`keyup`, Gamepad API. Nothing, while Power/Fwd/Rev logged correctly seconds apart in the same run |
+| Bonding the LE instance would expose it as a BLE-HID keyboard | No HID service (`0x1812`) on the device at all |
+| The device stops notifying under Bluetooth-audio load | nRF Connect receives every press reliably, including with audio active |
+| Chrome answers reads from an empty notification cache | Reads still return zero-length with notifications never enabled (`ble-read-empty … (notifications off)`) |
+| Our poll was wedged / not running | `ble-poll-tick` and ~7 reads/sec confirmed; failures are real resolved-but-empty values, not a stuck in-flight guard |
+| Bug is Android-specific | Desktop Linux Chrome (BlueZ) reproduces the identical zero-byte-read / silent-notify signature — see below |
+| Bug is permanent / present on every connection | Same characteristic, same desktop setup, later the same day: 150+ consecutive press/release notifications delivered with almost no misses. See [connection warm-up](#follow-up-testing-2026-09-05-connection-warm-up-not-a-permanent-bug) |
+| Wi-Fi/Bluetooth radio coexistence (AX200 shared antenna) is the cause | Looked confirmed by one Wi-Fi-off test, then contradicted by an even better result with Wi-Fi back on — see [connection warm-up](#follow-up-testing-2026-09-05-connection-warm-up-not-a-permanent-bug) |
+
+### Not yet tried
+
+- **Reading with a longer MTU / after a delay**, in case the zero-length
+  response is a negotiation artefact.
+- **A different OS's Web Bluetooth stack** (Windows/macOS use their native
+  BLE stacks, not BlueZ) — would tell us whether this is BlueZ-specific
+  rather than Chrome-specific.
+- **Filing a Chromium bug** about the empty-`properties` finding below, since
+  that reproduces on every characteristic on every service, not just the PTT
+  one, and looks like a GATT-discovery bug independent of the read/notify
+  problem.
+
+## Desktop Chrome (Linux) testing results, 2026-09-05
+
+Tested on a Debian 13 laptop, Intel AX200 adapter, Google Chrome 151, BlueZ
+5.82. Three platform-setup issues had to be cleared before the actual
+zero-byte question could even be tested:
+
+1. **`navigator.bluetooth` was `undefined`** out of the box. Web Bluetooth is
+   not on by default in Linux Chrome the way it is on Windows/macOS/ChromeOS/
+   Android — it needed `chrome://flags/#enable-experimental-web-platform-features`
+   set to Enabled, then a relaunch, before `requestDevice()` existed at all.
+2. **`getPrimaryService(SERVICE_UUID)` threw `NotFoundError`** on the first
+   connect after that, even though the device genuinely has that service.
+   Cause: this device's LE address had already been touched once by
+   `bluetoothctl` (for an unrelated pairing test) and disconnected quickly,
+   leaving BlueZ with a **stale, incomplete cached GATT attribute table** for
+   that address — `bluetoothctl info` showed only `0xFFE0` cached, not the
+   PTT service. Fix: `bluetoothctl remove <addr>` to forget the device
+   entirely, then reconnect fresh from the page so BlueZ redoes full
+   discovery. This is the desktop-Linux equivalent of the "clearing Android's
+   GATT attribute cache" theory from the list above — confirmed as a real
+   failure mode, just triggered here by a `bluetoothctl` session rather than
+   normal use.
+3. **The classic BR/EDR audio instance is a separate device** from the LE
+   GATT one (confirmed: different MAC, `29:D7:1F:7A:E3:47` vs
+   `29:D7:1F:9C:4E:58`) and needed its own pairing to stop the mic's
+   unconnected-blink LED — via `bluetoothctl`, this required switching the
+   agent to `NoInputNoOutput` (Just Works) first; the default `DisplayYesNo`
+   agent produced a numeric-comparison passkey prompt the device doesn't
+   actually support, which failed with `Authentication Failed (0x05)`. Not
+   relevant to the PTT bug itself, just a prerequisite for a clean setup.
+
+With a fresh device object and full discovery, the actual test:
+
+- **`byteLength` came back `0`** holding PTT and reading `894c8042-...` —
+  identical to the Android result. This rules out "Android-specific bug" per
+  the doc's own decision tree above.
+- **Subscribing to `894c8042-...` and pressing PTT produced zero
+  `characteristicvaluechanged` events**, again matching Android exactly.
+- **`chrome://bluetooth-internals`** turned out not to be the clean
+  bypass the original plan assumed: its Devices list is populated by its own
+  scan, and a device already GATT-connected via a page (and therefore not
+  currently advertising) doesn't show up there to Inspect. It disappeared
+  from the list entirely when attempting to inspect it, even though
+  `bluetoothctl info` confirmed the LE link was still `Connected: yes` the
+  whole time. Not a disconnect — a limitation of that internals page for
+  this use case. Untried: connecting *from* `bluetooth-internals` directly
+  (its own "New Connection" flow) rather than expecting it to show a
+  page-initiated connection.
+- **New finding, not previously documented:** `chr.properties` reports
+  **empty (`{}` / no flags true) for every characteristic on every service**,
+  not just the PTT one — `894c8042`, `ffe1`, `ff01`, `ff02`, `ff21`, `ff22`,
+  `ae01`, `ae02` all came back with an empty properties object via both
+  `getCharacteristic()` and `getCharacteristics()`. A real device does not
+  have zero properties on every characteristic; this looks like Chrome/BlueZ
+  on Linux failing to surface the GATT characteristic property flags at all,
+  a distinct bug from the zero-byte read/notify problem. Doesn't fully
+  explain the read/notify failures (Chrome does not appear to gate
+  `readValue()`/`startNotifications()` on client-side property flags), but
+  is a second, independently reproducible platform bug worth reporting
+  upstream.
+- **`0xFFE0` backup service — partial success.** Its notify characteristic is
+  `0xFFE1` (confirmed via `bluetoothctl`, matching the doc's original guess).
+  Subscribing to it and pressing PTT **did** produce real notifications
+  twice in one session — `byteLength=1 value=01` then, half a second later,
+  `byteLength=1 value=00` (each logged twice, i.e. delivered as a duplicate
+  pair) — out of roughly 50 button presses attempted. This is the first time
+  *any* characteristic on this device has delivered button state to Chrome
+  on any platform. But the loss rate (~1 full cycle in 50 presses) is severe,
+  consistent with the radio-contention flakiness already documented above
+  rather than a clean working channel. Not yet retried as a longer, isolated
+  session (i.e. subscribe once and leave it running, without intermixing
+  Enumerate-services calls, which may themselves be disruptive to an active
+  GATT session).
+
+**Net conclusion at this point in the day:** the zero-byte/silent-notify
+behavior on the documented PTT characteristic looked like a genuine
+cross-platform (Android + Linux desktop) Chrome/Web-Bluetooth-stack problem,
+not a phone-specific quirk, and `0xFFE0`/`0xFFE1` looked like the most
+promising lead, despite lossy delivery. **Superseded a few hours later** —
+see the follow-up section immediately below, where the primary characteristic
+turned out to work fine under the right connection conditions. Left in place
+because the empty-`properties` finding and the `chrome://bluetooth-internals`
+limitation are still real and unexplained, independent of the main mystery.
+
+## Follow-up testing, 2026-09-05: connection warm-up, not a permanent bug
+
+Same day, same desktop setup, continued testing turned up a race-condition
+fix and then a result that overturned the conclusion above.
+
+**1. `getPrimaryService()` can race GATT discovery on a never-before-seen
+device.** After a `bluetoothctl remove` (to clear a stale cache, see above),
+reconnecting produced the same `NotFoundError` — but the timestamps told a
+different story than "stale cache" this time: `gatt.connect()` resolved at
+`22:57:07.987` and the `NotFoundError` landed at `22:57:08.036`, **49ms**
+later. Real over-the-air GATT discovery of a whole attribute table takes
+hundreds of milliseconds at minimum. Chrome's `getPrimaryService()` call was
+simply racing BlueZ's own discovery on a device with zero prior cache to
+serve from. Fix: `getPrimaryServiceRetry()` wraps `getPrimaryService()` in retries with a
+500ms backoff (6 attempts) instead of failing on the first miss. This is a
+harness/client-code bug, not a device or platform bug. (The fix was described
+here before it was actually committed — the harness was still calling
+`getPrimaryService()` directly at all three call sites. Now genuinely present
+in `TD-Q2L-test.html`, and carried into HenWen as `_txBleService()`.)
+
+**2. Wi-Fi/Bluetooth coexistence looked like the answer, then wasn't.** With
+the classic BR/EDR audio link disconnected, comparing quick taps vs. held
+presses on `0xFFE1` showed **zero** deliveries during ~76 seconds of quick
+taps, then sparse hits, in a session with Wi-Fi on. Turning the laptop's
+Wi-Fi off entirely (`nmcli radio wifi off` — the Intel AX200 shares one
+antenna between Wi-Fi and Bluetooth, a known coexistence weak point) and
+re-running produced a dramatic change: dozens of clean press/release pairs
+delivered back-to-back with almost no gaps. At the time this looked like
+strong, direct confirmation that Wi-Fi contention on the shared AX200 antenna
+was the dominant cause of lost notifications.
+
+**3. That conclusion didn't survive the next test.** Wi-Fi was turned back
+on, and a fresh connection was made subscribing to **both** the primary PTT
+characteristic (`894c8042-...`) and `0xFFE1` at the same time. Result: **over
+150 consecutive press/release cycles delivered on both characteristics**,
+matching each other within single-digit milliseconds, for a full two-minute
+test — the best result of the entire day, obtained with Wi-Fi back on. This
+directly contradicts Wi-Fi state as the deciding factor: the exact condition
+blamed for the earlier failures was present during the best result of the
+day.
+
+**Revised theory: BLE connection-interval warm-up (or plain per-connection
+luck), not radio coexistence.** A BLE central and peripheral negotiate a
+"connection interval" — how often they exchange packets. A slow interval
+(commonly used to save the peripheral's battery when idle) means a quick
+press-and-release can complete entirely between two polling windows and
+never be seen by either side, not just delayed. Some stacks tighten the
+interval adaptively once sustained traffic starts flowing; separately, the
+initial interval a given connection lands on may simply vary run to run.
+Evidence this fits better than the Wi-Fi theory:
+
+- The Wi-Fi-off, `0xFFE1`-only session took **68 seconds** after
+  `startNotifications()` before the first successful delivery, then improved
+  gradually — consistent with a slow-to-fast interval transition taking time
+  to kick in.
+- The final, best session (subscribing to both characteristics, Wi-Fi on)
+  delivered its first success only **5 seconds** after subscribing, then
+  stayed reliable throughout — consistent with that particular connection
+  landing on a fast interval quickly, for reasons not yet isolated (more
+  simultaneous GATT traffic? plain variance?).
+- **Native BLE clients can request a high-priority connection interval
+  immediately after connecting** (e.g. Android's
+  `BluetoothGatt.requestConnectionPriority()`) — an API **Web Bluetooth does
+  not expose to JavaScript at all**. This cleanly explains why nRF Connect
+  has been 100% reliable in every test in this document, from the very first
+  press, on the same hardware where Chrome has ranged from 0% to
+  near-perfect: nRF Connect can force a fast interval on connect; a Chrome
+  page has no equivalent lever and is at the mercy of whatever interval the
+  connection happens to negotiate or drift into.
+
+**This means the primary PTT characteristic is not permanently broken in
+Chrome** — every earlier "zero bytes / silent notify" result in this
+document was real, but apparently connection-state-dependent rather than an
+unconditional platform limitation. The practical question for HenWen is no
+longer "is this characteristic readable from Chrome," but "how do we get (or
+wait for) a good connection interval before relying on it."
+
+**Not yet done:**
+- Capture the actual negotiated connection interval per session (e.g. via
+  `btmon`/`hcidump`) to confirm the interval-length theory directly instead
+  of inferring it from delivery timing alone.
+- Test whether deliberately generating GATT traffic immediately after
+  connect (e.g. a burst of reads on some characteristic, before the user's
+  first real PTT press) reliably shortens the time-to-fast-interval, which
+  would turn this into an actionable warm-up step in HenWen's own connect
+  code rather than a wait-and-hope.
+- Repeat the two-characteristics-at-once test a few more times to see how
+  often a fresh connection lands on a fast interval immediately vs. needs
+  time to get there — the sample size so far is one good session against
+  several bad ones.
+
+## Carried into HenWen, 2026-09-05
+
+Acting on the follow-up findings, `templates/status.html` now:
+
+- **retries service discovery** (`_txBleService()`, 6 tries / 500ms) rather
+  than trusting the first `NotFoundError`;
+- **subscribes again** — `TX_BLE_USE_NOTIFY` is back on, since the good
+  session proved notifications do work on this characteristic;
+- **subscribes to `0xFFE1` as a redundant second source**, not a fallback:
+  both delivered every press within single-digit milliseconds of each other
+  in the best session, and `_txBleApply()` de-duplicates, so whichever
+  arrives first wins. Non-`0x00`/`0x01` values are ignored, since a serial
+  passthrough can carry other traffic. Its characteristic is picked by UUID
+  rather than by `.notify`, because properties come back empty on Chrome/BlueZ;
+- **polls hard for the first 3 seconds** after connect (40ms, then settling to
+  150ms) as a **warm-up attempt**. This is the untested item from the list
+  above, now live: sustained GATT traffic is the only lever a page has, since
+  Web Bluetooth exposes no equivalent of
+  `BluetoothGatt.requestConnectionPriority()`. Whether it actually shortens
+  time-to-first-delivery is what the `ble-poll-start` → first `ble-value`
+  interval in `journalctl -u HenWen` will show, across several connects.
+
+Log lines to watch: `ble-svc-retry`, `ble-serial`, `ble-warmup-done`, and
+`ble-value … via poll|notify|ffe1` — the source tag says which transport
+actually delivered each press.
+
+## Phone result, 2026-09-05 evening: fast polling correlates with delivery
+
+First delivery of button state to Chrome **on the phone**, and it arrived
+with a sharp correlation attached. Connect at `19:47:27` started the poll at
+40ms as a 3-second warm-up:
+
+```
+19:47:27  ble-poll-start: 40ms warm-up for 3000ms
+19:47:28  ble-value: press via notify
+19:47:28  ble-value: release via notify
+19:47:29  ble-value: press via notify
+19:47:29  ble-value: release via notify
+19:47:30  ble-warmup-done: settled to 150ms
+   ...nothing further, for the rest of the session
+```
+
+Two clean press/release pairs while polling at 40ms; nothing at all after
+the poll relaxed to 150ms. This is the first time the phone has produced
+button state through Chrome by any route, and it supports the
+connection-interval theory directly rather than by inference from timing.
+
+**Caveat, and it is a real one:** TX was armed at `19:47:32`, one second
+after the warm-up ended. So this single run cannot separate "the poll rate
+dropped" from "Bluetooth audio started" — the original radio-contention
+theory predicts the same silence. The two are distinguishable by testing:
+with the fast poll now permanent, presses that keep working *after* arming
+point at the interval; presses that stop again at the moment of arming point
+at audio contention.
+
+Note also that the reads themselves stayed useless throughout —
+`ble-read-empty` at #1, #200, #400 — so the poll is not a data source on
+this device. It is a keep-alive whose only purpose is generating enough GATT
+traffic to hold a fast connection interval. **Notifications are what deliver
+the button; the poll is what appears to keep them flowing.**
+
+Acted on: the 40ms rate is no longer a warm-up that settles, it is the
+operating rate for as long as the link is up. The link only exists while an
+operator has deliberately connected a PTT button, so the cost is bounded.
+
+## Settled, 2026-09-05: BLE notifications and SCO audio cannot coexist
+
+With the keep-alive poll holding a fast connection interval, the variable
+that had been confounding every previous test was finally controlled — the
+poll ran at 40ms throughout all of the following, and the only thing that
+changed was whether TX was armed.
+
+| Window | TX state | Deliberate presses delivered |
+|---|---|---|
+| 19:55:56–19:56:09 | idle | **11 pairs**, every one |
+| 19:56:11–19:56:27 | **armed** | none |
+| 19:56:33–19:56:36 | idle again | **3 pairs**, immediately |
+| 20:01:49–20:02:09 | **armed**, 5 deliberate presses | none |
+
+Arming is what brings up the classic SCO audio link to the same headset. So
+the original mutual-exclusion claim in this file was right after all, and the
+retraction partway through was wrong — though reasonably made at the time:
+the operator reported mic, speaker and PTT all working together, which was
+true, but in a window where TX was not armed and no SCO link was up.
+
+`0xFFE1` was subscribed simultaneously and went equally silent, so this is
+not specific to the PTT characteristic. It is the radio.
+
+**What this settles, and what it costs.** Hold-to-talk over BLE is reachable
+on this device — 19 consecutive clean press/release pairs proves the link
+itself is solid once a fast connection interval is held — but *not while the
+mic's own audio is in use*. Since routing audio through the headset is the
+entire point of owning it, the practical answer for HenWen is that the **Rev
+media key stays the transmit control**: AVRCP rides through an active SCO
+link without trouble, where GATT does not. The cost is that Rev is a toggle
+rather than press-and-hold, with the guards described further down.
+
+The BLE path is kept and is genuinely useful for anyone *not* routing audio
+to the Bluetooth device — and HenWen now says plainly in the TX bar when a
+connected PTT button will not respond, rather than leaving it looking live.
+
+### A native Android app would not fix it either — tested, 2026-09-05
+
+The obvious escape hatch was to stop fighting Web Bluetooth and write a
+native app, since Android exposes
+`BluetoothGatt.requestConnectionPriority(CONNECTION_PRIORITY_HIGH)` — the
+API that asks for a fast connection interval, which Web Bluetooth does not
+expose to JavaScript in any form, and the single best explanation for why
+nRF Connect had been reliable from the first press where Chrome was not.
+
+**Tested before writing anything.** Every previous nRF Connect test had been
+run with no SCO link active, so the one condition that matters had never
+actually been checked. Run properly — a live call using the Q2L for audio,
+with nRF Connect connected and subscribed to `894c8042-…` alongside it —
+**nRF Connect receives no notifications either.**
+
+That settles the layer this lives at. nRF Connect is a native client already
+using every lever an Android app has, including connection priority. If it
+gets nothing while SCO is up, no app anyone writes gets anything either: the
+conflict is in the Bluetooth controller's scheduling of a single shared
+radio, below the application layer entirely. It is not a Chrome bug, not a
+Web Bluetooth limitation, and not something HenWen can code around.
+
+This also closes the remaining tuning idea — polling more slowly to leave
+radio time for SCO. No client-side strategy can matter when the best-case
+native client gets zero.
+
+### Still open
+
+- Whether a **two-radio accessory** (separate BLE and Classic Bluetooth
+  chips, rather than one combo chip) avoids this. That is the only remaining
+  route to hold-to-talk with Bluetooth audio, and it is a hardware purchase
+  rather than anything to build.
+
+## Troubleshooting on a desktop
+
+`TD-Q2L-test.html`, beside this file, is a standalone harness — no server-side
+component, nothing to do with HenWen. Pair the mic to the laptop, then:
+
+```bash
+cd docs/td-q2l && python3 -m http.server 8000
+# open http://localhost:8000/TD-Q2L-test.html in Chrome
+```
+
+`http://localhost` counts as a secure context, so Web Bluetooth works;
+`file://` does not. **Only one central can hold the LE link** — quit nRF
+Connect and close any HenWen tab before connecting, or the connect attempt
+fails with `Connection Error: Connection attempt failed.`
+
+Buttons, in order: **Connect**, **Enumerate services** (lists every
+characteristic under the PTT service and the three extras, with the
+properties Chrome sees — a second characteristic under the same UUID, or
+properties differing from nRF's, would explain the empty read), **Read once**,
+**Start poll**, **Subscribe**. The log shows `byteLength` and raw hex for
+every read and notification, and a PTT indicator turns red on `0x01`.
+
+The single question to answer first: **hold the button down and read — does
+`byteLength` come back 1 or 0?**
+
+- **1, value `0x01`** → desktop Chrome can read it and the fault is
+  Android-specific. HenWen's polling approach is correct as written and the
+  fix is a platform workaround (cache clear, different Chrome version) rather
+  than a code change.
+- **0** → Chrome cannot read this characteristic on any platform, and the
+  remaining avenues are `chrome://bluetooth-internals`, then the `0xFFE0`
+  serial service.
+
+**Answered 2026-09-05: it's `0` on desktop too** — see
+[Desktop Chrome (Linux) testing results](#desktop-chrome-linux-testing-results-2026-09-05)
+above for the full readout and what to try next (`0xFFE0`/`0xFFE1`, longer
+sustained subscribe sessions, other OS's native BLE stacks).
+
+## Known-working reference implementation
+
+HenWen (`/opt/HenWen`, this repo) drives PTT from the **Rev media key**, not
+from the proprietary BLE characteristic — see `_txMediaKeySync()` /
+`_txMediaKeyAction()` in `templates/status.html`. Confirmed working on real
+hardware 2026-09-05: repeated presses alternate cleanly, every press
+delivered.
+
+The BLE GATT path documented above is real and correctly implemented
+(`_txBleConnect()`), but in field use it never once delivered a press —
+it connects, subscribes successfully, then drops on its own. Since the Q2L
+is a plain Bluetooth headset to Android and its Fwd/Rev/Vol±/Play-Pause
+buttons are ordinary AVRCP keys the phone already handles, riding a media
+key is both simpler and far more reliable. The BLE code is kept for
+explicit, manual use and for anyone wanting to pursue the PTT-labelled
+button, but it is not the path in use.
+
+### Two non-obvious requirements for media keys to arrive
+
+An earlier attempt (commit 2d374a3, bound to play/pause) concluded media
+keys never reach the page. They do, but only under both of these:
+
+1. **The page must own the system media session**, which on Android means it
+   must actually be producing audible audio. HenWen's Listen stream through
+   its `<audio>` element earns that, and arming TX ensures Listen is running.
+   Setting `navigator.mediaSession.metadata` as well is what makes Android
+   surface it as the active media notification, rather than leaving the
+   headset's keys attached to whatever app played audio last.
+
+2. **The page must stay audible for the whole time you need keys.** This one
+   cost a day. HenWen muted its Listen element while transmitting (a
+   radio-style RX mute). Muting makes the page inaudible, Android hands the
+   media session away, and *no further media-key events are delivered* — so
+   the first press keyed the transmitter and nothing could release it. The
+   symptom reads exactly like a stuck button; the log showed no second event
+   arriving at all. Fix: duck to a near-zero volume (0.0001) instead of
+   muting. Inaudible in practice, still audible as far as the media session
+   is concerned.
+
+### Toggle semantics, and the safety that needs
+
+A media key is a single semantic action with no press/hold pair, so this is
+necessarily press-to-key / press-again-to-unkey, not hold-to-talk — the one
+thing the BLE characteristic would have done better, since it reports live
+button state. That makes a latched transmitter possible, so HenWen binds
+`previoustrack`/`play`/`pause` as **release-only**: any other button on the
+mic clears a stuck transmit, none of them can start one. A watchdog also
+unkeys at the node's own TOT, or 120s if none is configured.
+
+Binding play/pause has a second purpose: it stops the Power button pausing
+Listen while armed, which would drop the media session for the same reason
+muting did.
+
+## Open questions / untested
+
+- Whether other Tidradio PTT mic models/units share the same service and
+  characteristic UUIDs, or whether these are per-unit/per-batch.
+- Whether the BLE-advertising-window flakiness and the audio/BLE radio
+  conflict are related symptoms of the same underlying combo-chip
+  limitation, or independent issues.
+- Exact byte layout/keycodes for the Fwd/Rev/Volume/Power media keys — only
+  their functional effect was observed, not sniffed at the protocol level
+  (unnecessary, since they already work via standard OS media-key APIs).
+- Why the BLE GATT link connects and subscribes successfully but delivers no
+  notifications in field use, when nRF Connect sees every press. Moot for
+  HenWen now that PTT rides a media key, but unexplained.
+- Why Chrome/BlueZ on Linux reports empty `properties` for every
+  characteristic on this device (2026-09-05 finding, see desktop testing
+  results) — whether that's specific to this BlueZ version, this device, or
+  a broader Chromium-on-Linux Web Bluetooth bug worth reporting upstream.
+  Still true even in the session where notifications worked perfectly, so
+  it's independent of the connection-interval question.
+- Whether the connection-interval warm-up theory (see follow-up testing
+  section) is actually correct, and if so, whether HenWen can reliably force
+  or speed up a fast interval (e.g. a burst of GATT traffic right after
+  connect) rather than getting one only by chance.
+- What made the one good session land on a fast interval in 5 seconds while
+  other sessions took over a minute or never got there in the test window —
+  sample size is currently one good session against several bad ones.

--- a/templates/status.html
+++ b/templates/status.html
@@ -5021,20 +5021,50 @@ var _TX_IDLE_HANGUP_MS = 5 * 60 * 1000;  // auto-disarm after 5 min without keyi
 
 /* Mic gain: the browser's autoGainControl drove a headset mic to hard
    clipping (media-source audioLevel pinned at 1.000, "much too loud" on a
-   parrot test), so AGC is off and level is set manually with this slider —
-   the mic runs through a WebAudio gain stage before it enters the call,
-   with a post-gain analyser feeding the level meter (what the meter shows
-   is what transmits). Persisted per browser. */
+   parrot test), so AGC is off by default and level is set manually with
+   this slider — the mic runs through a WebAudio gain stage before it
+   enters the call, with a post-gain analyser feeding the level meter (what
+   the meter shows is what transmits). Persisted per browser. */
 function _txSavedGain() {
   var v = parseInt(localStorage.getItem('henwen-tx-gain') || '100', 10);
   return (v >= 0 && v <= 200) ? v : 100;
 }
 
+/* AGC stays off; the manual gain slider above is the level control. Worth
+   recording what turning it on costs and buys, since it was tried and
+   reverted: Chromium's Android backend only engages Bluetooth audio routing
+   when getUserMedia asks for the full default AEC+NS+AGC trio, so opting AGC
+   out means a paired headset's mic and speaker are not used for the call at
+   all. Turning it on restored that routing — and re-introduced the clipping
+   the slider exists to avoid (see _txSavedGain above). Off is the status quo
+   until someone wants headset routing badly enough to re-tune the level. */
 function _txBuildMicChain() {
   return navigator.mediaDevices.getUserMedia({
     audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: false },
     video: false,
   }).then(function(raw) {
+    /* Which mic actually got picked, and which processing Chrome actually
+       applied, are the two facts that decide whether this sounds right —
+       and both are decided by the browser, not by what we asked for. Log
+       the resolved values so "which mic is this actually using, and with
+       what processing?" is a journalctl line rather than a guess — the one
+       question behind most "my audio sounds wrong" reports. */
+    try {
+      var t = raw.getAudioTracks()[0], s = (t.getSettings && t.getSettings()) || {};
+      _txDiag('mic-source', 'label=' + (t.label || '?') +
+              ' agc=' + s.autoGainControl + ' ns=' + s.noiseSuppression +
+              ' aec=' + s.echoCancellation + ' rate=' + s.sampleRate);
+      /* A track label of "Default" names Chrome's default-device alias, not
+         the hardware behind it, so on its own it can't say which mic was
+         actually used. Listing the input devices alongside it can. Labels
+         are only populated post-permission, which is why this runs after
+         getUserMedia rather than before. */
+      navigator.mediaDevices.enumerateDevices().then(function(ds) {
+        _txDiag('mic-devices', ds.filter(function(d) { return d.kind === 'audioinput'; })
+                                 .map(function(d) { return d.label || d.deviceId.slice(0, 8); })
+                                 .join(' | ').slice(0, 200));
+      }).catch(function() {});
+    } catch (e) {}
     _tx.rawStream = raw;
     _tx.audioCtx  = new (window.AudioContext || window.webkitAudioContext)();
     var src  = _tx.audioCtx.createMediaStreamSource(raw);
@@ -5077,11 +5107,15 @@ function _txStartMeter() {
    log (was DTMF actually sent? was the mic track live? was the outbound RTP
    audio level non-zero?) without browser devtools open. */
 function _txDiag(type, detail) {
-  if (!_tx.node) return;
+  /* _tx.node is only set once armTx()'s config fetch resolves, so fall back
+     to the board's own local node number rather than going silent for
+     anything reported before that point. */
+  var node = _tx.node || (window._lastBoardNodes && window._lastBoardNodes[0] && window._lastBoardNodes[0].node) || '';
+  if (!node) return;
   try {
     apiFetch('/api/audio/client-log', {
       method: 'POST', headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({node: _tx.node, type: 'tx-' + type, detail: String(detail).slice(0, 200)}),
+      body: JSON.stringify({node: node, type: 'tx-' + type, detail: String(detail).slice(0, 200)}),
       keepalive: true,
     });
   } catch (e) {}
@@ -5821,6 +5855,8 @@ function _txTouchIdle() {
   }, _TX_IDLE_HANGUP_MS);
 }
 
+/* Mute Listen only while keyed — the radio-style RX mute. Restored on
+   unkey so the operator hears their own repeater tail as confirmation. */
 /* Mute Listen only while keyed — the radio-style RX mute. Restored on
    unkey so the operator hears their own repeater tail as confirmation. */
 function _txMuteListen(muted) {


### PR DESCRIPTION
Brings main level with what's running on `/opt/HenWen`, so the live checkout can track `main` again — which matters because `update.sh` pulls `main`.

## TX mic diagnostics

`tx-mic-source` logs the resolved track label and the processing Chrome actually applied; `tx-mic-devices` lists the enumerated inputs. Which device got used, and with what processing, are the browser's decisions rather than ours — and they're the two facts behind most "my audio sounds wrong" reports. Having them in `journalctl` is what let several audio problems this week be diagnosed from the server log without devtools open on a phone.

`_txDiag` also falls back to the board's own local node number, so anything reported before `armTx()` resolves its config is no longer silently dropped.

## TD-Q2L research → `docs/td-q2l/`

The notes and the standalone Web Bluetooth harness, moved off the repo root with their internal paths updated. **The integration was abandoned and no TD-Q2L code remains in the app** — this is a record, not a plan.

It's worth keeping because it establishes, with evidence:

- the mic's PTT button emits nothing a web page can observe — verified against all 15 Media Session actions, DOM `keydown`/`keyup` and the Gamepad API, in a run where its other buttons logged correctly as a live control;
- its proprietary BLE characteristic works well (19 consecutive clean press/release pairs) but goes silent whenever Bluetooth audio is in use, which is the point of owning the mic;
- a native Android app doesn't help either — nRF Connect, which already calls `requestConnectionPriority()`, receives nothing during an active call, placing the conflict in the Bluetooth controller's scheduling of one shared radio.

Several conclusions in that file were reached and later overturned on real evidence; the sequence is left visible on purpose rather than tidied into a clean story.

`CLAUDE.md` gains a short pointer to it, so the next attempt at a Bluetooth PTT accessory starts there instead of rederiving a day of dead ends.

460 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GPgxBagLmVecSDfqG1rhp