### PR TITLE
Ask before installing deps, apt-get update first, note HTTPS/reverse-proxy

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,15 +21,44 @@ if [ "$EUID" -ne 0 ]; then
     exit 1
 fi
 
-# ── Python check ─────────────────────────────────────────
+# ── Required system packages ──────────────────────────────
+# python3 itself, plus the venv module (python3-venv/python3-full) needed
+# to create the app's virtualenv -- Debian/Ubuntu ship python3 without
+# ensurepip by default, so `python3 -m venv` fails outright without it.
+# Rather than silently apt-get installing whatever's missing, state what's
+# needed and ask before touching the system -- and always apt-get update
+# first, so a stale package list doesn't 404 mid-install (as it did on an
+# out-of-date Debian 12 box: idle-python3.11/python3.11-venv/etc. all
+# 404'd, `python3 -m venv` then failed for real, and the venv module's own
+# error message told the user to re-run the exact apt-get install that had
+# already just failed).
+NEED_PKGS=()
 if ! command -v python3 &>/dev/null; then
-    echo "[1/9] Installing Python 3..."
-    apt-get install -y python3 python3-pip python3-venv python3-full
-else
-    echo "[1/9] Python 3 found: $(python3 --version)"
+    NEED_PKGS+=(python3 python3-pip)
+fi
+if ! python3 -c "import ensurepip" &>/dev/null; then
+    NEED_PKGS+=(python3-venv python3-full)
 fi
 
-apt-get install -y python3-venv python3-full 2>/dev/null || true
+if [ ${#NEED_PKGS[@]} -gt 0 ]; then
+    echo "[1/9] Missing required package(s): ${NEED_PKGS[*]}"
+    DO_INSTALL=1
+    if [ -t 0 ]; then
+        read -p "      Install via apt-get now? [Y/n]: " REPLY
+        [[ "$REPLY" =~ ^[Nn] ]] && DO_INSTALL=0
+    fi
+    if [ "$DO_INSTALL" -ne 1 ]; then
+        echo "      Skipped. Install these manually, then re-run this script:"
+        echo "        sudo apt-get update && sudo apt-get install -y ${NEED_PKGS[*]}"
+        exit 1
+    fi
+    echo "      Running apt-get update..."
+    apt-get update
+    echo "      Installing: ${NEED_PKGS[*]}"
+    apt-get install -y "${NEED_PKGS[@]}"
+else
+    echo "[1/9] Python 3 found: $(python3 --version), venv module available."
+fi
 
 # ── Copy files ────────────────────────────────────────────
 echo "[2/9] Installing to $INSTALL_DIR..."
@@ -249,6 +278,10 @@ if systemctl is-active --quiet "$SERVICE_NAME"; then
     # it's opt-in and skipped entirely on a non-interactive install.
     if [ -t 0 ]; then
         echo ""
+        echo "  Note: skip this if HenWen will run behind an existing reverse proxy"
+        echo "  (e.g. nginx, Caddy, or another Apache instance) that already terminates"
+        echo "  HTTPS for you -- this step provisions its own standalone Apache +"
+        echo "  Let's Encrypt HTTPS listener, which isn't what you want in that case."
         read -p "  Set up HTTPS now for the browser TX button? Requires a public hostname pointed at this box. [y/N]: " SETUP_HTTPS
         if [[ "$SETUP_HTTPS" =~ ^[Yy] ]]; then
             bash "$INSTALL_DIR/tx-spike/setup-https.sh" || echo "  HTTPS setup failed — you can re-run it later: sudo bash $INSTALL_DIR/tx-spike/setup-https.sh"

--- a/tx-spike/setup-https.sh
+++ b/tx-spike/setup-https.sh
@@ -121,6 +121,11 @@ fi
 
 # ── Install Apache + certbot ───────────────────────────────
 echo "[2/7] Installing Apache and certbot..."
+# apt-get update first -- a stale package list here 404s the same way it did
+# for install.sh's python3-venv install (see install.sh's own comment on
+# this), and this step is unattended (--non-interactive certbot below), so
+# there's no later error message pointing back at a fix.
+apt-get update
 apt-get install -y apache2 certbot python3-certbot-apache
 a2enmod ssl proxy proxy_http proxy_wstunnel headers rewrite >/dev/null
 


### PR DESCRIPTION
## Summary
- `install.sh` no longer silently `apt-get install`s Python packages: it computes what's actually missing (`python3`/`python3-pip` if `python3` itself is absent, `python3-venv`/`python3-full` if the `ensurepip` module isn't importable), states it, and asks for confirmation on an interactive run (auto-proceeds unattended, same as before, for scripted installs).
- Runs `apt-get update` before installing anything, so a stale package list doesn't 404 mid-install the way it did on the reporter's out-of-date Debian 12 box (`idle-python3.11`, `python3.11-venv`, etc. all 404'd, then `python3 -m venv` failed for real with a message that just told them to re-run the exact `apt-get install` that had already silently failed).
- Removes the old unconditional, error-suppressed `apt-get install -y python3-venv python3-full 2>/dev/null || true` that ran even when nothing was missing and hid its own failures.
- Adds a note on the HTTPS setup prompt that it doesn't apply to installs already running behind an existing reverse proxy (nginx/Caddy/another Apache) — this step provisions its own standalone Apache + Let's Encrypt listener.

Closes #67

## Test plan
- [x] `bash -n install.sh` — syntax check passes
- [ ] Fresh Debian 12 VM with a stale apt cache — confirm the missing-package prompt appears, `apt-get update` runs first, and install proceeds without 404s
- [ ] Non-interactive install (e.g. piped via CI) — confirm no prompt blocks and install proceeds automatically as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111dDvKwRgB7X69D9Pk9rVY