### PR TITLE
Stop presenting sudo as an install prerequisite (#70)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ cd HenWen
 sudo bash install.sh
 ```
 
+No `sudo` on the box? It isn't required — run the same thing from a root shell (`su -`, then `bash install.sh`). See [Does HenWen need sudo?](https://github.com/GooseThings/HenWen/wiki/Installation#does-henwen-need-sudo) for what that does and doesn't change.
+
 Then open `http://YOUR_NODE_IP:5000` to create your Owner account. The installer runs AMI setup for you interactively — full walkthrough (AMI setup, rotating the secret key, verifying rpt.conf, updating) is in the **[Installation guide](https://github.com/GooseThings/HenWen/wiki/Installation)**.
 
 ## Documentation

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 # HenWen - Installer
 # https://www.github.com/GooseThings/HenWen/
-# Run as root: sudo bash install.sh
+# Run as root — either `sudo bash install.sh`, or `bash install.sh` from a
+# root shell. sudo is a convenience here, not a dependency: this script only
+# ever requires EUID 0 and never invokes sudo itself.
 set -e
 
 INSTALL_DIR="/opt/HenWen"
@@ -17,7 +19,13 @@ echo ""
 
 # ── Root check ────────────────────────────────────────────
 if [ "$EUID" -ne 0 ]; then
-    echo "ERROR: Please run as root: sudo bash install.sh"
+    echo "ERROR: install.sh must run as root."
+    echo ""
+    echo "  With sudo:     sudo bash install.sh"
+    echo "  Without sudo:  su -   then   bash install.sh"
+    echo ""
+    echo "  (sudo is not required to install or run HenWen — see the"
+    echo "   Installation guide's \"Does HenWen need sudo?\" section.)"
     exit 1
 fi
 
@@ -230,7 +238,20 @@ asterisk ALL=(root) NOPASSWD: ${INSTALL_DIR}/update_service_ports.sh
 asterisk ALL=(root) NOPASSWD: ${SYSTEMD_RUN_BIN} --unit=henwen-updater --collect ${INSTALL_DIR}/update.sh
 asterisk ALL=(root) NOPASSWD: ${INSTALL_DIR}/audiosocket-tap/apply.sh
 EOF
-if visudo -c -f "${SUDOERS_FILE}.tmp" &>/dev/null; then
+# visudo ships as part of the sudo package, so "no visudo" means sudo simply
+# isn't installed on this box — a legitimate choice, not an error. Say so
+# plainly instead of reporting it as a failed validation, which is what the
+# single else-branch used to do and which read like something had gone wrong
+# with the install (issue #70).
+if ! command -v visudo >/dev/null 2>&1; then
+    rm -f "${SUDOERS_FILE}.tmp"
+    echo "      sudo is not installed — skipping this rule."
+    echo "      HenWen installs and runs normally without it. The only things"
+    echo "      that stop working are the Manager UI buttons needing root:"
+    echo "      Restart Asterisk/HenWen, Launch Updater, rotate SECRET_KEY,"
+    echo "      change ports. Do those from a root shell instead, or install"
+    echo "      sudo and re-run install.sh."
+elif visudo -c -f "${SUDOERS_FILE}.tmp" &>/dev/null; then
     chmod 440 "${SUDOERS_FILE}.tmp"
     mv "${SUDOERS_FILE}.tmp" "$SUDOERS_FILE"
     echo "      Installed $SUDOERS_FILE"


### PR DESCRIPTION
Addresses #70.

The install guide opened Step 1 with *"you'll need to update, upgrade, and then install sudo first"*, and `install.sh`'s own non-root error said *"Please run as root: sudo bash install.sh"*. Both conflate **needs root** with **needs sudo**. The reporter's point is fair: installing sudo is a sysadmin choice, not something an app gets to mandate — and if HenWen's scripting does depend on it, that should be stated as a recommendation with a reason.

## What's actually true

I checked rather than assuming either way:

- **`install.sh` requires `EUID 0` and nothing more.** It never invokes sudo — every `sudo` in the file is inside an echoed message or a comment. `su -` then `bash install.sh` is a fully supported path.
- **sudo *is* a real runtime dependency, but only for privileged Manager UI actions.** The service runs unprivileged as `asterisk` and escalates through the narrowly-scoped rule `install.sh` writes to `/etc/sudoers.d/henwen-systemctl`: `restart asterisk`, `restart HenWen`, `daemon-reload`, `rotate_secret_key.sh`, `update_service_ports.sh`, `systemd-run` (Launch Updater), `audiosocket-tap/apply.sh`.
- **Without sudo the install still completes.** `visudo` ships in the sudo package, so validation simply fails — and because that call is an `if` condition, `set -e` doesn't abort and the installer carries on to finish.

So the honest summary is: sudo isn't needed to install or run HenWen; it's needed for a specific list of buttons, and skipping it costs you those buttons and nothing else.

## Changes

**`install.sh` — the "no sudo" case is no longer reported as a failure.** It previously printed `generated sudoers rule failed validation`, which reads like the install broke when nothing had gone wrong. Now a three-way branch:

| Case | Output |
|---|---|
| sudo absent | explains it plainly as a supported configuration, lists what won't work |
| rule invalid | the real warning, unchanged |
| success | unchanged |

All three verified to continue past the block under `set -e`.

**`install.sh` — non-root error** now gives both routes (`sudo bash install.sh` / `su -` then `bash install.sh`) and notes sudo isn't required.

**`README.md`** gains a one-liner pointing at the wiki's new "Does HenWen need sudo?" section.

## Wiki

The quoted text lives in the wiki, not this repo, so it isn't in this PR. I have the `Installation.md` rewrite staged locally — Step 1 restructured around root-vs-sudo, a new **"Does HenWen need sudo?"** section with the command table above, and the Requirements list marking sudo *optional but recommended*. Wikis have no PR mechanism and push straight to live, so I've left it unpushed pending your say-so.

## Testing

Docs/messaging only — no behaviour change to the sudoers rule itself, and nothing changes for anyone who does have sudo. Suite unchanged at **460 passing**; `install.sh` checked with `bash -n` and its branch logic exercised in isolation. Deliberately never by running the installer — it hardcodes `INSTALL_DIR=/opt/HenWen` and would self-copy over the live deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EA4CzLZu9XiAJpRqt3dtR9
