### PR TITLE
Ask before installing Apache/certbot for HTTPS setup (#75)

### DIFF
--- a/tx-spike/setup-https.sh
+++ b/tx-spike/setup-https.sh
@@ -120,13 +120,49 @@ else
 fi
 
 # ── Install Apache + certbot ───────────────────────────────
-echo "[2/7] Installing Apache and certbot..."
-# apt-get update first -- a stale package list here 404s the same way it did
-# for install.sh's python3-venv install (see install.sh's own comment on
-# this), and this step is unattended (--non-interactive certbot below), so
-# there's no later error message pointing back at a fix.
-apt-get update
-apt-get install -y apache2 certbot python3-certbot-apache
+echo "[2/7] Checking for Apache and certbot..."
+# Ask before touching the system, mirroring install.sh's own dependency
+# prompt (see its NEED_PKGS block). Answering "yes" to *set up HTTPS* is
+# not the same as consenting to apt-get pulling in three packages, and
+# this script shouldn't treat it as such -- reported as issue #75.
+#
+# Only the genuinely-missing packages are named and installed, so a re-run
+# on a box that already has them prompts for nothing and changes nothing.
+# dpkg-query's Status field is the check rather than `dpkg -s`, which also
+# succeeds for a removed-but-not-purged package still holding config files.
+HTTPS_PKGS=(apache2 certbot python3-certbot-apache)
+NEED_HTTPS_PKGS=()
+for pkg in "${HTTPS_PKGS[@]}"; do
+    dpkg-query -W -f='${Status}' "$pkg" 2>/dev/null | grep -q '^install ok installed$' \
+        || NEED_HTTPS_PKGS+=("$pkg")
+done
+
+if [ ${#NEED_HTTPS_PKGS[@]} -gt 0 ]; then
+    echo "      HTTPS setup needs these package(s): ${NEED_HTTPS_PKGS[*]}"
+    DO_HTTPS_INSTALL=1
+    if [ -t 0 ]; then
+        read -p "      Install via apt-get now? [Y/n]: " REPLY
+        [[ "$REPLY" =~ ^[Nn] ]] && DO_HTTPS_INSTALL=0
+    fi
+    if [ "$DO_HTTPS_INSTALL" -ne 1 ]; then
+        echo "      Skipped — HTTPS is not set up, and the browser TX button will"
+        echo "      stay hidden until it is. Everything else works over plain HTTP."
+        echo "      To do it yourself later:"
+        echo "        sudo apt-get update && sudo apt-get install -y ${NEED_HTTPS_PKGS[*]}"
+        echo "        sudo bash $0 $HOSTNAME_ARG $EMAIL_ARG"
+        exit 1
+    fi
+    # apt-get update first -- a stale package list here 404s the same way it did
+    # for install.sh's python3-venv install (see install.sh's own comment on
+    # this), and this step is unattended (--non-interactive certbot below), so
+    # there's no later error message pointing back at a fix.
+    echo "      Running apt-get update..."
+    apt-get update
+    echo "      Installing: ${NEED_HTTPS_PKGS[*]}"
+    apt-get install -y "${NEED_HTTPS_PKGS[@]}"
+else
+    echo "      Already installed: ${HTTPS_PKGS[*]}"
+fi
 a2enmod ssl proxy proxy_http proxy_wstunnel headers rewrite >/dev/null
 
 if [ "$HTTPS_PORT" != "443" ]; then


### PR DESCRIPTION
Closes #75.

#68 fixed half of this already — `setup-https.sh` runs `apt-get update` before installing. The other half stood: it went straight from *"yes, set up HTTPS"* to

```bash
apt-get install -y apache2 certbot python3-certbot-apache
```

with no prompt naming those packages. Consenting to HTTPS setup isn't consenting to three packages being pulled onto the box, and the script shouldn't conflate the two. This was the **last unasked package install in the repo**.

## Approach

`install.sh`'s own `NEED_PKGS` block (added by #68) already does this properly, so this mirrors it rather than inventing a second pattern:

- name the packages that are **actually missing**, before doing anything
- prompt `[Y/n]`, defaulting to yes
- on `n`, print the exact `apt-get` line *and* the re-run command, then stop
- guard the prompt with `[ -t 0 ]` so a non-interactive run proceeds rather than hanging on a `read` nothing will answer

Two things improve beyond the literal ask:

**Idempotent re-runs.** Only genuinely-missing packages are named and installed, so re-running on a box that already has them prompts for nothing and installs nothing — previously it re-ran `apt-get install` unconditionally every time. Detection uses `dpkg-query`'s Status field rather than `dpkg -s`, which also reports success for a removed-but-not-purged package still holding config files.

**The declined path explains the cost.** HTTPS is only needed for the browser TX button's secure context; nothing else in HenWen requires it. So declining says exactly that, instead of just bailing out.

## Verification

Exercised the block in isolation with `apt-get` stubbed — deliberately **never** by running `setup-https.sh` itself, which provisions a real Apache vhost and a real Let's Encrypt certificate.

| Case | Result |
|---|---|
| all three present | `Already installed: …` — no prompt, no install |
| missing, non-interactive | proceeds, no hang |
| missing, answers `n` | skips with guidance, exits non-zero |
| missing, presses Enter | proceeds (default yes) |

The `dpkg-query` check was separately validated against real installed packages and a non-existent one. Suite unchanged at **460 passing**; `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EA4CzLZu9XiAJpRqt3dtR9
