### PR TITLE
Don't flash the node OFFLINE on a single dropped poll (#69)

### DIFF
--- a/templates/status.html
+++ b/templates/status.html
@@ -3841,6 +3841,30 @@ function _drawFavicon(state) {
 var _lastBoardOk = Date.now();   /* seeded at load so the watchdog doesn't fire before the first fetch has even had a chance to land */
 var BOARD_STALE_MS = 8000;       /* ~4 missed 2s polls (see the refreshBoard interval below) before flagging the server unreachable */
 
+/* One failed poll is not an outage. refreshBoard() used to call
+   markServerUnreachable() on the very first failure, which contradicted the
+   8s/~4-poll tolerance the watchdog right below it was deliberately built
+   with — so a single dropped request produced a visible OFFLINE blink even
+   though the next poll, 2s later, succeeded. On any real network (a phone on
+   WiFi across a house, to a Pi) the occasional dropped fetch is normal, and
+   every one of them flashed the badge. Reported in issue #69 as OFFLINE
+   flashing roughly every 15 seconds on an otherwise healthy node; the same
+   install stopped showing it once the board was reached over a different
+   URL/network path, which is the signature of transport blips rather than
+   anything the server did.
+   Tolerating BOARD_FAIL_TOLERANCE consecutive failures lines this path up
+   with the watchdog: a genuine outage is still surfaced within ~6s, while a
+   one-off blip is absorbed. */
+var BOARD_FAIL_TOLERANCE = 3;
+var _boardFailStreak = 0;
+
+function noteBoardFailure(why) {
+  _boardFailStreak++;
+  if (_boardFailStreak >= BOARD_FAIL_TOLERANCE) markServerUnreachable();
+  else console.debug('[board] poll failed (' + _boardFailStreak + '/' +
+                     BOARD_FAIL_TOLERANCE + ', not flagging yet):', why);
+}
+
 function markServerUnreachable() {
   var dot = document.querySelector('.keyed-dot');
   var label = document.querySelector('.keyed-label');
@@ -3856,12 +3880,23 @@ function boardWatchdog() {
 }
 
 async function refreshBoard() {
+  var data;
+  /* Split deliberately: only the fetch/parse below is evidence about whether
+     the server is reachable. Everything after it is rendering, and a bug in
+     rendering must not be reported as the node being offline — see the second
+     catch at the end of this function. */
   try {
     var r = await apiFetch('/api/status/board', {cache: 'no-store'});
-    if (!r.ok) { markServerUnreachable(); return; }
-    var data = await r.json();
-    _lastBoardOk = Date.now();
+    if (!r.ok) { noteBoardFailure('HTTP ' + r.status); return; }
+    data = await r.json();
+  } catch (e) {
+    noteBoardFailure(e);
+    return;
+  }
+  _lastBoardOk     = Date.now();
+  _boardFailStreak = 0;
 
+  try {
     /* Node card */
     var nodes = data.nodes || [];
     window._lastBoardNodes = nodes;
@@ -4028,7 +4063,15 @@ async function refreshBoard() {
        wrapping, the ONLINE/OFFLINE badge, the LOCKED row), and doing it here
        costs one layout flush instead of one per intervening mutation. */
     dashFitNodeCard();
-  } catch(e) { markServerUnreachable(); }
+  } catch (e) {
+    /* A rendering bug is not a reachability problem. This catch used to call
+       markServerUnreachable(), so a null element or a Leaflet error anywhere
+       in the ~165 lines above told the operator their node was OFFLINE — and
+       swallowed the actual error silently, so nothing ever got fixed. Report
+       it where a developer can see it and leave the badge alone: the fetch
+       succeeded, so the server is demonstrably reachable. */
+    console.error('[board] render failed:', e);
+  }
 }
 
 /* Generic "Xh Ym"/"Xm"/"Xs" duration formatter — shared by the APRS station


### PR DESCRIPTION
Fixes the flashing badge in #69 for HTTP users — without needing to know why the underlying blip happens.

## The code contradicted itself

`refreshBoard()` called `markServerUnreachable()` on the **very first** failed poll. The watchdog immediately below it was deliberately built with tolerance, and says so in its own comment:

```js
var BOARD_STALE_MS = 8000;   /* ~4 missed 2s polls ... before flagging the server unreachable */
```

Two paths, opposite policies — and the intolerant one wins, because it fires first. So one dropped fetch produced a visible OFFLINE blink even though the next poll 2s later succeeded.

On any real network — a phone on WiFi across a house, talking to a Pi — the occasional dropped request is normal, and **every one of them flashed the badge.** That matches #69's report exactly: a badge flashing OFFLINE every ~15s on a demonstrably healthy node, nothing in the journal, and the symptom going away once the same install was reached over a different URL and network path.

Worth stating plainly: this explains the "HTTPS fixed it" observation without any transport-specific mechanism. I measured both serving paths on a live box first — `/api/status/board` answers in **5ms direct and 15ms through Apache, zero errors either way** — so the server was never the variable. HTTPS is in fact 3× slower here. What changed for that operator was the network path, and this code turned a single blip on that path into a visible fault.

## Change 1 — tolerate a blip

A failure now increments a streak and only flags at `BOARD_FAIL_TOLERANCE` (3 consecutive), aligning this path with the watchdog it was contradicting. A genuine outage still surfaces in ~6s; a one-off blip is absorbed. The streak resets on any success.

## Change 2 — a rendering bug is not an outage

Found in the same function: the trailing `catch(e) { markServerUnreachable(); }` wrapped the **entire** body, so a null element or a Leaflet error anywhere in the ~165 lines of rendering below the fetch reported the *node* as OFFLINE — blaming the repeater for a JS error on the page — and swallowed the exception silently, so no such bug could ever be noticed or fixed.

Rendering now has its own catch that logs to the console and leaves the badge alone. The fetch succeeded, so the server is demonstrably reachable whatever went wrong afterwards.

## Verification

There's no JS test suite here, so I extracted the real functions from `status.html` and drove them under node against a stubbed fetch/DOM:

| Scenario | Badge |
|---|---|
| 1 failure, then success | **ONLINE** (absorbed) |
| 2 failures, then success | **ONLINE** (absorbed) |
| 3 consecutive failures | **OFFLINE** (genuine outage) |
| 3 thrown network errors | **OFFLINE** (same as non-ok) |
| blip, blip, success, blip, blip | **ONLINE** (streak reset) |
| fetch ok, render throws | **ONLINE** + console error |

That last row proved itself incidentally and repeatedly — the minimal DOM stub throws during rendering on *every* successful fetch, and the badge stays ONLINE with the error logged. Under the old code every one of those would have reported OFFLINE.

Page JS parses clean under `node --check`; Python suite unchanged at **474 passing**.

## Relationship to the rest of #69

- #72 (merged) — the missing first-run screen.
- #78 (merged) — `[BOARD-HEALTH]` journal logging. Still useful, and now the way to tell these apart: if the badge ever flips again *with* a `BOARD-HEALTH OFFLINE` line, it's a real server-side condition; silence means the browser's fetch failed, which is what this PR now tolerates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EA4CzLZu9XiAJpRqt3dtR9
