### PR TITLE
Preserve other apps on the box when claiming a hostname for HTTPS (#77)

### DIFF
--- a/tx-spike/README.md
+++ b/tx-spike/README.md
@@ -42,6 +42,16 @@ you're wiring that path up by hand instead of via Apache).
   `/etc/apache2/sites-enabled/henwen-ssl.conf` — the exact path `apply.sh`
   and `check-ports.sh` expect — even though certbot's own naming
   convention would otherwise call it `henwen-le-ssl.conf`.
+  **Other apps on the box are preserved.** The vhost proxies `/` to HenWen,
+  which would otherwise swallow every other URL on that hostname (issue
+  #77: Allmon3 and AllScan started 404ing, while still working by raw IP
+  since an IP doesn't match `ServerName`). So before claiming the hostname
+  it scans the default `DocumentRoot` and emits `ProxyPass /<dir> !` for
+  each directory already there, above the catch-all, and prints what it
+  preserved. A directory whose name collides with one of HenWen's own URLs
+  (`api`, `status`, `login`, `static`, …) can't be excluded without
+  breaking HenWen, so those are reported as a warning instead and stay
+  reachable by IP.
 - `modules.snippet` — PJSIP/WebRTC module loads appended to `modules.conf`
   (ASL3 SIP-phone guide's set + websocket transport + SRTP)
 - `pjsip.snippet` — WS transport + one `henwen-tx` endpoint (`webrtc=yes`,

--- a/tx-spike/setup-https.sh
+++ b/tx-spike/setup-https.sh
@@ -135,6 +135,73 @@ if [ "$HTTPS_PORT" != "443" ]; then
         echo "Listen ${HTTPS_PORT}" >> /etc/apache2/ports.conf
 fi
 
+# ── Preserve whatever else this box already serves ─────────
+# A catch-all `ProxyPass / -> Flask` on a *named* vhost hijacks every URL on
+# that hostname, including apps that were working long before HenWen was
+# installed. Allmon3 and AllScan live under the default DocumentRoot on a
+# great many AllStar nodes, and issue #77 reported exactly that: /allmon3/
+# and /allscan/ began returning 404 (Flask has no such route) the moment
+# this vhost claimed the hostname, while the same paths still worked by raw
+# IP -- because an IP doesn't match ServerName, so it fell through to the
+# default vhost, which was still serving them perfectly well.
+#
+# So before claiming the hostname, look at what the default site already
+# serves and exclude each of those paths with `ProxyPass /<dir> !`. Apache
+# honours an exclusion only when it appears *before* the catch-all, hence
+# the insertion point below. Excluded paths are then served straight from
+# DocumentRoot exactly as they were.
+HENWEN_RESERVED=(accept-invite accessible api asl3-ez-manager forgot-password
+                 henwen-manager login logout reset-password status static)
+EXCL_MARKER="# HenWen: preserve paths this box already served (issue #77)"
+
+DOCROOT=$(awk '/^[[:space:]]*DocumentRoot[[:space:]]+/ {print $2; exit}' \
+          /etc/apache2/sites-enabled/*.conf 2>/dev/null)
+[ -n "$DOCROOT" ] || DOCROOT=/var/www/html
+DOCROOT="${DOCROOT%/}"
+
+PRESERVED=()
+SHADOWED=()
+if [ -d "$DOCROOT" ]; then
+    for _d in "$DOCROOT"/*/; do
+        [ -d "$_d" ] || continue
+        _name=$(basename "$_d")
+        # Anything needing quoting would produce a malformed directive; a
+        # directory named like that isn't a served app worth guessing about.
+        case "$_name" in *[!A-Za-z0-9._-]*) continue ;; esac
+        # Never shadow HenWen's own routes -- the operator explicitly pointed
+        # this hostname at HenWen, so on a collision HenWen has to win. Say so
+        # rather than silently picking a side.
+        if printf '%s\n' "${HENWEN_RESERVED[@]}" | grep -qxF "$_name"; then
+            SHADOWED+=("$_name")
+            continue
+        fi
+        PRESERVED+=("$_name")
+    done
+fi
+
+# Insert the DocumentRoot + exclusions immediately above the catch-all
+# ProxyPass in a vhost file. Idempotent (marker check), and a no-op when
+# there's nothing to preserve, so re-running the script never stacks
+# duplicates.
+inject_exclusions() {
+    local conf="$1" line tmp injected=0 n
+    [ -f "$conf" ] || return 0
+    [ "${#PRESERVED[@]}" -gt 0 ] || return 0
+    grep -qF "$EXCL_MARKER" "$conf" && return 0
+    tmp=$(mktemp)
+    while IFS= read -r line; do
+        if [ "$injected" -eq 0 ] && \
+           [[ "$line" =~ ^[[:space:]]*ProxyPass[[:space:]]+/[[:space:]]+http://127\.0\.0\.1: ]]; then
+            printf '    DocumentRoot %s\n' "$DOCROOT"
+            printf '    %s\n' "$EXCL_MARKER"
+            for n in "${PRESERVED[@]}"; do printf '    ProxyPass /%s !\n' "$n"; done
+            injected=1
+        fi
+        printf '%s\n' "$line"
+    done < "$conf" > "$tmp"
+    mv "$tmp" "$conf"
+}
+
 # ── Base HTTP vhost (port 80) ──────────────────────────────
 echo "[3/7] Writing Apache vhost for $HOSTNAME_ARG..."
 cat > "$HTTP_AVAIL" <<VHOST
@@ -145,6 +212,18 @@ cat > "$HTTP_AVAIL" <<VHOST
     ProxyPassReverse / http://127.0.0.1:${FLASK_PORT}/
 </VirtualHost>
 VHOST
+inject_exclusions "$HTTP_AVAIL"
+
+if [ "${#PRESERVED[@]}" -gt 0 ]; then
+    echo "      Preserving paths already served from ${DOCROOT}: ${PRESERVED[*]}"
+    echo "      (these keep working on $HOSTNAME_ARG instead of being proxied to HenWen)"
+fi
+if [ "${#SHADOWED[@]}" -gt 0 ]; then
+    echo "      WARNING: ${DOCROOT} also contains: ${SHADOWED[*]}"
+    echo "      Those names collide with HenWen's own URLs, so HenWen wins on"
+    echo "      $HOSTNAME_ARG and they stay reachable only by IP. Rename them if"
+    echo "      you need both on this hostname."
+fi
 a2ensite "${CONF_NAME}.conf" >/dev/null
 apache2ctl configtest
 systemctl reload apache2
@@ -202,6 +281,13 @@ if [ -f "$SSL_AVAIL" ] && ! grep -qE '^\s*ProxyPass\s+/ http://127\.0\.0\.1:'"${
         sed -i "/<\/VirtualHost>/i\\    ProxyPreserveHost On\\n    ProxyPass        / http://127.0.0.1:${FLASK_PORT}/ retry=0 timeout=120\\n    ProxyPassReverse / http://127.0.0.1:${FLASK_PORT}/" "$SSL_AVAIL"
     fi
 fi
+
+# Same preservation for the SSL vhost. certbot builds it by copying the :80
+# vhost, so the exclusions are usually carried over already -- inject_exclusions
+# is a no-op then (marker check). This covers the case where certbot rewrites
+# or reorders enough that they don't survive the copy, and costs nothing when
+# they did.
+inject_exclusions "$SSL_AVAIL"
 
 apache2ctl configtest
 systemctl reload apache2


### PR DESCRIPTION
Closes #77.

## What went wrong

`setup-https.sh` wrote a **named** vhost for the operator's hostname whose `ProxyPass` sent *everything* under `/` to Flask:

```apache
<VirtualHost *:80>
    ServerName allstar.weisb.net
    ProxyPass        / http://127.0.0.1:5000/ retry=0 timeout=120
</VirtualHost>
```

That vhost then beat Apache's default for that hostname, so every other app on the box became a HenWen 404 — and certbot's `--redirect` closed the plain-HTTP escape hatch too. The reporter lost `/allmon3/` and `/allscan/`, both near-universal on AllStar nodes.

The tell in their report was that the same paths **still worked by raw IP**. An IP doesn't match `ServerName`, so it fell through to the default vhost, which had been serving them correctly the whole time. That confirmed the takeover rather than any breakage of the apps themselves.

## The fix

Before claiming the hostname, the script scans the default `DocumentRoot` and emits an exclusion for each directory already there, **above** the catch-all — Apache only honours an exclusion that precedes it:

```apache
    DocumentRoot /var/www/html
    # HenWen: preserve paths this box already served (issue #77)
    ProxyPass /allmon3 !
    ProxyPass /allscan !
    ProxyPass /supermon !
    ProxyPass        / http://127.0.0.1:5000/ retry=0 timeout=120
```

It sets `DocumentRoot` so those paths resolve, and prints what it preserved rather than doing it silently.

**Collisions are surfaced, not guessed at.** A directory named after one of HenWen's own routes (`api`, `status`, `login`, `static`, …) can't be excluded without breaking HenWen — and the operator *did* explicitly point this hostname at HenWen — so HenWen wins and the collision is reported as a warning naming the directory. Directories whose names would need shell quoting are skipped rather than emitting a malformed directive.

The same injection also runs against the certbot-generated SSL vhost. certbot usually copies the `:80` vhost wholesale, so the exclusions are normally already present and it's a no-op via its marker check; this covers the case where they don't survive the copy.

## Verification

Deliberately **without running the installer** — it provisions a real Apache vhost and a real Let's Encrypt certificate. The real functions were extracted and driven against a fake `DocumentRoot` containing `allmon3`, `allscan`, `supermon`, a colliding `api`, a space-containing directory, and a plain file:

| Check | Result |
|---|---|
| apps preserved | `allmon3 allscan supermon` |
| collision with a HenWen route | `api` reported as shadowed, not excluded |
| space-containing dir / plain file | both ignored |
| exclusions precede the catch-all | line 8 < line 9 ✓ |
| inject twice more | no duplicates (idempotent) |
| empty DocumentRoot | vhost byte-identical |
| missing SSL vhost | returns cleanly under `set -e` |

The generated config was then handed to Apache's own parser — `apache2 -t` against an isolated throwaway `ServerRoot`, never the live configuration — which accepts it.

`bash -n` clean; Python suite unchanged at **474 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EA4CzLZu9XiAJpRqt3dtR9
