### PR TITLE
Let uninstall.sh remove accounts and credentials (#80)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,14 @@ cd /opt/HenWen
 sudo bash install.sh   # copies files to /opt/HenWen, installs venv, enables service
 ```
 
+**Uninstall:**
+```bash
+sudo bash uninstall.sh                # asks whether to delete data/credentials
+sudo bash uninstall.sh --purge        # delete them, no prompt
+sudo bash uninstall.sh --keep-data    # keep them, no prompt
+```
+`install.sh` deliberately preserves `/etc/asterisk/henwen.db` so an in-place reinstall doesn't wipe the operator's accounts and config. The consequence nobody expected was that uninstall-then-reinstall silently restored working admin logins from before (issue #80) — the DB holds every password hash, TOTP secret and recovery code, plus the saved Broadcastify/YouTube/Discord/IRC/Meshtastic/ntfy/Pushover credentials. So `uninstall.sh` now asks before deleting that (and the TX SIP secret, recordings, TTS voices, uploaded sounds), defaulting to **keep** since deletion is irreversible, and a non-interactive run without `--purge` always keeps. It removes the `henwen-systemctl` sudoers rule unconditionally, though — a standing passwordless-root grant pointing at paths under a now-deleted `/opt/HenWen` is not something to leave behind. `rpt.conf`, its backups, and any Apache vhost/certificate from `setup-https.sh` are deliberately never touched.
+
 There is no linter configuration. Unit tests exist under `tests/` — see **Testing** below.
 
 ## Testing

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,9 +1,41 @@
 #!/bin/bash
 # HenWen - Uninstaller
+#
+# Run as root — either `sudo bash uninstall.sh`, or `bash uninstall.sh` from a
+# root shell. sudo is a convenience here, not a dependency: this script only
+# ever requires EUID 0 and never invokes sudo itself.
 set -e
 
+usage() {
+    cat <<USAGE
+Usage: bash uninstall.sh [--purge | --keep-data]
+
+  --purge      Also delete HenWen's database, credentials, recordings, TTS
+               voices and uploaded sounds. No prompt.
+  --keep-data  Remove the application only, leaving all data in place. No
+               prompt.
+
+With neither flag an interactive run asks. A non-interactive run keeps the
+data and says so — an unattended uninstall never destroys data silently.
+USAGE
+}
+
+PURGE=""      # "" = ask, 1 = purge, 0 = keep
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --purge)      PURGE=1 ;;
+        --keep-data)  PURGE=0 ;;
+        -h|--help)    usage; exit 0 ;;
+        *) echo "Unknown option: $1"; echo; usage; exit 1 ;;
+    esac
+    shift
+done
+
 if [ "$EUID" -ne 0 ]; then
-    echo "Please run as root: sudo bash uninstall.sh"
+    echo "ERROR: uninstall.sh must run as root."
+    echo ""
+    echo "  With sudo:     sudo bash uninstall.sh"
+    echo "  Without sudo:  su -   then   bash uninstall.sh"
     exit 1
 fi
 
@@ -12,6 +44,59 @@ echo "============================================"
 echo "  HenWen Uninstaller"
 echo "============================================"
 echo ""
+
+# Everything holding account credentials or user data. The database is the
+# important one and the reason this prompt exists at all (issue #80): it holds
+# every account's password hash, TOTP secret and recovery codes, plus the
+# credentials for every integration configured through the Manager —
+# Broadcastify password, YouTube stream key, Discord webhook URLs, IRC NickServ
+# password, Meshtastic channel PSK, ntfy/Pushover tokens. install.sh
+# deliberately preserves it so an in-place reinstall doesn't wipe the operator's
+# accounts and configuration; the consequence nobody expected is that
+# uninstall-then-reinstall silently restored working admin logins from before.
+DATA_PATHS=(
+    "/etc/asterisk/henwen.db|database: all accounts, 2FA secrets and saved integration credentials"
+    "/etc/asterisk/henwen-tx.secret|SIP secret for the browser TX button"
+    "/var/lib/asterisk/henwen_recordings|saved audio recordings"
+    "/var/lib/asterisk/henwen_tts_voices|downloaded Piper TTS voice models"
+    "/usr/share/asterisk/sounds/henwen|uploaded announcement and node-ID audio"
+)
+
+present_paths() {
+    local entry path
+    for entry in "${DATA_PATHS[@]}"; do
+        path="${entry%%|*}"
+        [ -e "$path" ] && printf '%s\n' "$entry"
+    done
+}
+
+FOUND=()
+while IFS= read -r line; do [ -n "$line" ] && FOUND+=("$line"); done < <(present_paths)
+
+if [ "${#FOUND[@]}" -gt 0 ]; then
+    echo "HenWen data and credentials found on this system:"
+    echo ""
+    for entry in "${FOUND[@]}"; do
+        printf '    %-42s %s\n' "${entry%%|*}" "${entry#*|}"
+    done
+    echo ""
+    if [ -z "$PURGE" ]; then
+        if [ -t 0 ]; then
+            echo "Keeping these means a future reinstall comes back with the same"
+            echo "accounts and passwords still working."
+            read -p "Delete them? [y/N]: " REPLY
+            [[ "$REPLY" =~ ^[Yy] ]] && PURGE=1 || PURGE=0
+        else
+            # Never destroy data in an unattended run that didn't ask for it.
+            PURGE=0
+            echo "Non-interactive run and no --purge given — keeping all of the above."
+        fi
+    fi
+else
+    PURGE=0
+    echo "No HenWen data files found on this system."
+    echo ""
+fi
 
 echo "Stopping and disabling HenWen service..."
 systemctl stop    HenWen 2>/dev/null || true
@@ -25,10 +110,53 @@ rm -f /etc/systemd/system/asl3-rpt-editor.service
 
 systemctl daemon-reload
 
+# The sudoers rule grants the asterisk user passwordless root for a handful of
+# systemctl commands and two HenWen scripts. Leaving it behind for an app that
+# no longer exists is a standing grant pointing at paths anyone able to write
+# /opt/HenWen could recreate — so it goes unconditionally, not as part of the
+# data prompt.
+echo "Removing sudoers rule and journald cap..."
+rm -f /etc/sudoers.d/henwen-systemctl
+rm -f /etc/systemd/journald.conf.d/99-henwen-cap.conf
+systemctl restart systemd-journald 2>/dev/null || true
+
 echo "Removing installation directory /opt/HenWen..."
 rm -rf /opt/HenWen
 
+if [ "$PURGE" = "1" ]; then
+    echo "Removing HenWen data and credentials..."
+    for entry in "${FOUND[@]}"; do
+        path="${entry%%|*}"
+        rm -rf "$path"
+        echo "      removed $path"
+    done
+fi
+
 echo ""
-echo "Uninstall complete."
-echo "Your rpt.conf and backups in /etc/asterisk/ were NOT removed."
+echo "============================================"
+echo "  Uninstall complete."
+echo "============================================"
+echo ""
+if [ "$PURGE" = "1" ]; then
+    echo "  All HenWen accounts and stored credentials were deleted."
+    echo "  A future install will start from the first-run setup screen."
+else
+    if [ "${#FOUND[@]}" -gt 0 ]; then
+        echo "  KEPT: HenWen's database and credentials are still on this system."
+        echo "        A reinstall will reuse them — the same accounts and"
+        echo "        passwords will work again. Re-run with --purge to remove"
+        echo "        them, or delete them yourself:"
+        echo ""
+        for entry in "${FOUND[@]}"; do
+            echo "          rm -rf ${entry%%|*}"
+        done
+        echo ""
+    fi
+fi
+echo "  Left alone (not HenWen's to remove):"
+echo "    /etc/asterisk/rpt.conf and /etc/asterisk/rpt_backups/"
+echo "    Apache vhosts and any Let's Encrypt certificate from setup-https.sh"
+echo "      (/etc/apache2/sites-*/henwen*.conf — check 'apache2ctl -S')"
+echo "    The firewall rule opening the web port, if install.sh added one"
+echo "    Asterisk's own AudioSocket dialplan, if audiosocket-tap was applied"
 echo ""


### PR DESCRIPTION
Closes #80.

## What was happening

`uninstall.sh` removed the service unit and `/opt/HenWen` and stopped there, so `/etc/asterisk/henwen.db` survived — and `install.sh` preserves that file **deliberately**, to keep an in-place reinstall from wiping the operator's accounts and configuration. The consequence nobody had thought through is exactly the one reported: uninstall, reinstall, and the old admin logins still work.

The database is worse than "credentials" implies. It holds every account's password hash, TOTP secret and recovery codes, plus everything configured through the Manager — Broadcastify password, YouTube stream key, both Discord webhook URLs, IRC NickServ password, Meshtastic channel PSK, ntfy/Pushover tokens. Alongside it the old script also left the browser-TX SIP secret, recordings, downloaded TTS voices, and uploaded announcement audio.

## Change 1 — ask, and say what's at stake

It now lists exactly what it found:

```
HenWen data and credentials found on this system:

    /etc/asterisk/henwen.db          database: all accounts, 2FA secrets and saved integration credentials
    /etc/asterisk/henwen-tx.secret   SIP secret for the browser TX button
    /var/lib/asterisk/henwen_recordings   saved audio recordings
    ...

Keeping these means a future reinstall comes back with the same
accounts and passwords still working.
Delete them? [y/N]:
```

`--purge` and `--keep-data` skip the prompt.

**The default is keep**, which is the one judgment call here and easy to overrule if you'd rather it were `[Y/n]`. Reasoning: deletion is irreversible, the prompt states the consequence plainly so it's an informed choice rather than a silent one, and the actual complaint was the *surprise*, not the retention. A non-interactive run without `--purge` also always keeps — an unattended uninstall should never destroy data on its own.

## Change 2 — the sudoers rule goes unconditionally

Found while mapping what gets left behind: `/etc/sudoers.d/henwen-systemctl` also survived. It grants the `asterisk` user passwordless root for several `systemctl` commands and two scripts under `/opt/HenWen`. Leaving a standing grant pointing into a directory that no longer exists — and that anything able to write there could recreate — isn't something to leave to a prompt, so it's removed every time, along with the journald drop-in.

## What it still won't touch

Now stated explicitly in the closing summary rather than left to be discovered: `rpt.conf` and its backups, any Apache vhost or Let's Encrypt certificate from `setup-https.sh`, the firewall rule, and Asterisk's AudioSocket dialplan. After #77, ripping out web server configuration this project doesn't own is the last thing it should do.

## Verification

Running this for real would delete the live install and database, so it was exercised in a sandbox: every absolute path rewritten under a temp dir, `systemctl` stubbed, and a safety gate that aborts if any `rm` still names a real path.

| Case | Result |
|---|---|
| tty, `y` | purges all 5 data paths |
| tty, `n` | keeps all 5, prints warning + manual `rm` lines |
| tty, bare Enter | keeps (default N) |
| `--purge` | purges, no prompt |
| `--keep-data` | keeps, no prompt |
| non-interactive, no flag | keeps, says so |
| no data present | no prompt, clean exit |

The sudoers rule is removed in every one. The interactive three were run under a real pty via `script`, since piping stdin makes `[ -t 0 ]` false and silently exercises the non-interactive branch instead — which is how the first run of the harness accidentally proved that branch works.

`bash -n` clean; Python suite unchanged at **474 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EA4CzLZu9XiAJpRqt3dtR9
