### PR TITLE
Show Web Transceiver clients in Connected Nodes (#74)

### DIFF
--- a/app.py
+++ b/app.py
@@ -2318,8 +2318,17 @@ class AMIClient:
         e.g. "2,2324RU,666380TK" — node 2324 in mode R(monitor), Unkeyed;
         node 666380 in mode T(transceive), Keyed.
 
-        Connected nodes come from 'rpt lstats <node>' which gives one line
-        per connected node containing the remote node number.
+        Connected nodes come from 'rpt lstats <node>', one line per connected
+        peer.
+
+        A peer id is NOT always a node number. A Web Transceiver client shows
+        up under its callsign in both sources — 'rpt lstats' as
+        "NT0Y  73.145.245.30  0  IN  00:20:32:549  ESTABLISHED", and
+        RPT_ALINKS as "1,NT0YTU" — so neither parser may assume digits (issue
+        #74). Peer ids therefore flow through as opaque strings. lookup_node()
+        already tolerates that: a callsign misses allmondb/astdb and gets a
+        negative cache entry, so it costs one dict slot rather than a fetch per
+        board refresh.
         """
         status = {"keyed": False, "connected": [], "links": {}, "raw": [], "lstats": [],
                   "link_connect_seconds": {}, "link_direction": {}, "link_connect_state": {}}
@@ -2335,7 +2344,27 @@ class AMIClient:
             m = re.search(r'\bRPT_ALINKS\s*=\s*\d+,(.+)$', line)
             if m:
                 for entry in m.group(1).split(","):
-                    em = re.match(r'^(\d{4,7})([A-Za-z]*)$', entry.strip())
+                    entry = entry.strip()
+                    # "<peer><mode><K|U>" — peer is normally a node number, but
+                    # a Web Transceiver client appears under its *callsign*
+                    # instead (confirmed live: RPT_ALINKS=1,NT0YTU, i.e. NT0Y in
+                    # mode T, Unkeyed). Splitting on character class the way the
+                    # numeric-only parse below does cannot work for a callsign,
+                    # since letters and digits mix freely in one. The trailing
+                    # mode+keyed pair is always exactly two characters, so take
+                    # those off the end and treat whatever precedes them as the
+                    # peer id, whatever shape it has. See issue #74.
+                    em = re.match(r'^(.+?)([A-Za-z])([KU])$', entry)
+                    if em:
+                        status["links"][em.group(1)] = {
+                            "keyed": em.group(3) == "K",
+                            "mode":  em.group(2),
+                        }
+                        continue
+                    # Anything not ending in a mode+K/U pair falls back to the
+                    # original numeric parse, so every shape that already worked
+                    # is handled identically to before.
+                    em = re.match(r'^(\d{4,7})([A-Za-z]*)$', entry)
                     if em:
                         link_node, flags = em.group(1), em.group(2)
                         status["links"][link_node] = {
@@ -2353,7 +2382,22 @@ class AMIClient:
         log("DEBUG", f"[AMI] rpt lstats {node} -> {lstats}")
         for line in lstats:
             parts = line.split()
-            if len(parts) >= 5 and re.match(r'^\d{4,7}$', parts[0]):
+            # A data row is recognised by its DIRECTION column (IN/OUT), not by
+            # the peer column looking like a node number. A Web Transceiver
+            # client connects under a callsign — confirmed live, `rpt lstats`
+            # reporting "NT0Y  73.145.245.30  0  IN  00:20:32:549  ESTABLISHED"
+            # — so testing parts[0] against ^\d{4,7}$ dropped the whole row
+            # silently and the client never appeared in Connected Nodes
+            # (issue #74). DIRECTION also rejects the two non-data rows that a
+            # looser peer-shaped pattern would let through: the header puts
+            # "DIRECTION" at index 3 (because "CONNECT TIME" is two words), and
+            # the "----" separator has dashes there.
+            is_row = len(parts) >= 5 and parts[3].upper() in ("IN", "OUT")
+            # Keep the original numeric test as a fallback so an app_rpt build
+            # with a different column order behaves exactly as it did before.
+            if not is_row:
+                is_row = len(parts) >= 5 and re.match(r'^\d{4,7}$', parts[0]) is not None
+            if is_row:
                 cn = parts[0]
                 if cn != str(node) and cn not in status["connected"]:
                     status["connected"].append(cn)

--- a/templates/status.html
+++ b/templates/status.html
@@ -1819,6 +1819,14 @@ function nodeLink(node, cssClass) {
   if (_ECHOLINK_NODE_RE.test(String(node))) {
     return '<span class="' + cssClass + '">' + esc(node) + '</span><span class="el-badge" title="EchoLink node">EL</span>';
   }
+  /* Not every connected peer is a node number. A Web Transceiver client shows
+     up under its callsign (issue #74), and stats.allstarlink.org indexes nodes
+     only — so pointing one at /stats/NT0Y is a guaranteed dead link. QRZ is
+     both valid and more useful for a callsign, and callsignLink() already
+     handles the SSID/modifier stripping that needs. */
+  if (CALLSIGN_RE.test(String(node).toUpperCase())) {
+    return callsignLink(node, cssClass);
+  }
   return '<a class="' + cssClass + '" href="https://stats.allstarlink.org/stats/' +
     encodeURIComponent(node) + '" target="_blank" rel="noopener">' + esc(node) + '</a>';
 }

--- a/tests/test_lstats_parsing.py
+++ b/tests/test_lstats_parsing.py
@@ -1,0 +1,126 @@
+"""Unit tests for AMIClient.get_node_status()'s parsing of `rpt lstats` and
+RPT_ALINKS.
+
+Issue #74: a Web Transceiver client connects under its *callsign*, not a node
+number, and both parsers required 4-7 digits — so the client was dropped
+silently and never appeared in the Connected Nodes panel. The fixtures below
+are the verbatim output the reporter captured from their node.
+
+get_node_status() only needs AMIClient.command() to return lines, so these
+drive a bare instance with that one method stubbed rather than standing up a
+real AMI connection.
+"""
+import pytest
+
+import app
+
+
+# Verbatim from issue #74, node 628280 with a Web Transceiver client attached.
+LSTATS_CALLSIGN = [
+    "NODE      PEER                RECONNECTS  DIRECTION  CONNECT TIME        CONNECT STATE",
+    "----      ----                ----------  ---------  ------------        -------------",
+    "NT0Y      73.145.245.30       0           IN         00:20:32:549        ESTABLISHED",
+]
+VARS_CALLSIGN = [
+    "RPT_TXKEYED=0",
+    "RPT_NUMLINKS=1",
+    "RPT_LINKS=1,TNT0Y",
+    "RPT_NUMALINKS=1",
+    "RPT_ALINKS=1,NT0YTU",
+    "RPT_RXKEYED=0",
+]
+
+# An ordinary numeric peer, to prove the old path is untouched.
+LSTATS_NUMERIC = [
+    "NODE      PEER                RECONNECTS  DIRECTION  CONNECT TIME        CONNECT STATE",
+    "----      ----                ----------  ---------  ------------        -------------",
+    "27664     44.1.2.3            0           OUT        01:02:03:456        ESTABLISHED",
+]
+VARS_NUMERIC = ["RPT_RXKEYED=1", "RPT_ALINKS=2,2324RU,666380TK"]
+
+
+def _status(monkeypatch, vars_lines, lstats_lines, node="628280"):
+    client = app.AMIClient.__new__(app.AMIClient)   # no socket, no connect
+
+    def fake_command(cmd, log_level=None):
+        return vars_lines if "show variables" in cmd else lstats_lines
+
+    monkeypatch.setattr(client, "command", fake_command, raising=False)
+    return client.get_node_status(node)
+
+
+class TestCallsignPeer:
+    """The issue #74 case."""
+
+    def test_callsign_peer_appears_in_connected(self, monkeypatch):
+        st = _status(monkeypatch, VARS_CALLSIGN, LSTATS_CALLSIGN)
+        assert st["connected"] == ["NT0Y"]
+
+    def test_header_and_separator_rows_are_not_treated_as_peers(self, monkeypatch):
+        st = _status(monkeypatch, VARS_CALLSIGN, LSTATS_CALLSIGN)
+        assert "NODE" not in st["connected"]
+        assert "----" not in st["connected"]
+        assert len(st["connected"]) == 1
+
+    def test_direction_and_connect_time_are_parsed(self, monkeypatch):
+        st = _status(monkeypatch, VARS_CALLSIGN, LSTATS_CALLSIGN)
+        assert st["link_direction"]["NT0Y"] == "IN"
+        assert st["link_connect_seconds"]["NT0Y"] == 20 * 60 + 32
+        assert st["link_connect_state"]["NT0Y"] == "ESTABLISHED"
+
+    def test_alinks_splits_callsign_from_mode_flags(self, monkeypatch):
+        """NT0YTU -> callsign NT0Y, mode T (transceive), U (unkeyed)."""
+        st = _status(monkeypatch, VARS_CALLSIGN, LSTATS_CALLSIGN)
+        assert st["links"] == {"NT0Y": {"keyed": False, "mode": "T"}}
+
+
+class TestNumericPeerUnchanged:
+    """Everything that worked before must parse identically."""
+
+    def test_numeric_peer_still_parsed(self, monkeypatch):
+        st = _status(monkeypatch, VARS_NUMERIC, LSTATS_NUMERIC)
+        assert st["connected"] == ["27664"]
+        assert st["link_direction"]["27664"] == "OUT"
+        assert st["link_connect_seconds"]["27664"] == 3600 + 2 * 60 + 3
+
+    def test_alinks_numeric_entries_match_previous_behaviour(self, monkeypatch):
+        """The docstring's own example: 2324 monitor/unkeyed, 666380 TX/keyed."""
+        st = _status(monkeypatch, VARS_NUMERIC, LSTATS_NUMERIC)
+        assert st["links"] == {
+            "2324":   {"keyed": False, "mode": "R"},
+            "666380": {"keyed": True,  "mode": "T"},
+        }
+
+    def test_rxkeyed_still_detected(self, monkeypatch):
+        assert _status(monkeypatch, VARS_NUMERIC, LSTATS_NUMERIC)["keyed"] is True
+
+
+class TestEdgeCases:
+    def test_the_nodes_own_number_is_never_listed_as_a_peer(self, monkeypatch):
+        lstats = [
+            "NODE      PEER          RECONNECTS  DIRECTION  CONNECT TIME   CONNECT STATE",
+            "628280    44.1.2.3      0           IN         00:00:10:000   ESTABLISHED",
+        ]
+        assert _status(monkeypatch, [], lstats, node="628280")["connected"] == []
+
+    def test_empty_lstats_yields_no_peers(self, monkeypatch):
+        st = _status(monkeypatch, [], [])
+        assert st["connected"] == [] and st["links"] == {}
+
+    def test_alinks_entry_without_mode_flags_falls_back_to_numeric(self, monkeypatch):
+        st = _status(monkeypatch, ["RPT_ALINKS=1,12345"], [])
+        assert st["links"] == {"12345": {"keyed": False, "mode": ""}}
+
+    def test_duplicate_rows_are_not_double_listed(self, monkeypatch):
+        lstats = LSTATS_CALLSIGN + [LSTATS_CALLSIGN[-1]]
+        assert _status(monkeypatch, VARS_CALLSIGN, lstats)["connected"] == ["NT0Y"]
+
+    @pytest.mark.parametrize("callsign", ["W1AW", "KE8WNV", "N8GMZ", "M0ABC", "VK2XYZ"])
+    def test_a_range_of_real_callsign_shapes_parse(self, monkeypatch, callsign):
+        lstats = [
+            "NODE   PEER        RECONNECTS  DIRECTION  CONNECT TIME   CONNECT STATE",
+            f"{callsign}   10.0.0.1    0           IN         00:00:05:000   ESTABLISHED",
+        ]
+        st = _status(monkeypatch, [f"RPT_ALINKS=1,{callsign}TU"], lstats)
+        assert st["connected"] == [callsign]
+        assert st["links"] == {callsign: {"keyed": False, "mode": "T"}}


### PR DESCRIPTION
Closes #74.

## Root cause

A Web Transceiver client connects under its **callsign**, not a node number. From the reporter's own node:

```
NODE   PEER            RECONNECTS  DIRECTION  CONNECT TIME   CONNECT STATE
NT0Y   73.145.245.30   0           IN         00:20:32:549   ESTABLISHED

RPT_LINKS=1,TNT0Y
RPT_ALINKS=1,NT0YTU
```

Both parsers in `get_node_status()` required `^\d{4,7}$`, so the row was dropped entirely and the client never appeared in Connected Nodes — silently, which is also why nothing showed in the journal.

## Backend

**`rpt lstats`** — a data row is now recognised by its **DIRECTION column** being `IN`/`OUT`, rather than by the peer column looking numeric. That's a stronger test than any peer-shaped pattern, because it also rejects the two rows such a pattern would wrongly accept: the header puts `DIRECTION` at index 3 (since "CONNECT TIME" is two words) and the `----` separator has dashes there. The original numeric test is kept as a fallback, so an app_rpt build with a different column order behaves exactly as before.

**`RPT_ALINKS`** — `NT0YTU` can't be split on character class the way a numeric peer can, since letters and digits mix freely in a callsign. The trailing mode+keyed pair is always exactly two characters, so those come off the end and whatever precedes them is the peer id. Verified byte-identical results for the numeric entries in the function's own docstring example (`2324RU` → mode R unkeyed, `666380TK` → mode T keyed), with the old numeric parse retained for entries carrying no flags.

Peer ids now flow through as opaque strings. `lookup_node()` already tolerates that — a callsign misses allmondb and astdb and gets a **negative cache entry**, costing one dict slot rather than an HTTP fetch per board refresh. That negative caching was added for unknown *numeric* nodes and happens to cover this exactly; without it, this change would have put a network call on the 2s board poll.

## Frontend

`nodeLink()` sent every non-EchoLink peer to `stats.allstarlink.org/stats/<id>`, which indexes node numbers only — so a callsign peer would have rendered a guaranteed-dead link. It now routes a callsign to QRZ through the existing `callsignLink()`/`_qrzCallsign()` helpers, which already handle SSID and operating-modifier stripping.

Checked `CALLSIGN_RE` both directions so nothing that used to reach the ASL stats page stops reaching it:

| Input | Result |
|---|---|
| `1999`, `2324`, `27664`, `628280`, `643930`, `666380`, `3151197` | no match → ASL stats link, unchanged |
| `NT0Y`, `W1AW`, `KE8WNV`, `N8GMZ`, `M0ABC`, `VK2XYZ`, `8N8N` | match → QRZ link |

## Testing

**16 new tests**, fixtured on the reporter's verbatim output: the callsign case, header/separator rejection, the numeric path unchanged, the node's own number never listing itself, duplicate rows, an ALINKS entry with no flags, and a range of international callsign shapes.

Proved non-vacuous by running the same assertions against the unfixed tree:

```
BEFORE (/opt/HenWen):  connected = []        -> visible: NO
AFTER  (this branch):  connected = ['NT0Y']  -> visible: YES
```

Suite **474 → 490 passing**; `app.py` byte-compiles and the page JS parses clean under `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EA4CzLZu9XiAJpRqt3dtR9
