### PR TITLE
Fix insufficient color contrast on TX/Listen node-control buttons

### DIFF
--- a/templates/status.html
+++ b/templates/status.html
@@ -415,16 +415,23 @@ html, body { height: 100%; background: var(--bg); color: var(--text);
    app's many color themes (see :root above) is active rather than baking
    in one palette's hex values.
    .btn-active is toggled by _txSetBtn()/_listenSetBtn()/_recordSetBtn()
-   exactly when each one's inline text color is set to its own active-state
-   color (TX armed/Listen active = their own tint; Rec active is already
-   red) — see those functions. Text/icon color while active still comes
-   from that same inline style, not from this rule, so the two always
-   agree. */
+   exactly when each one's inline text color is set — TX armed/Listen active
+   pass their own tint as that sentinel value, see those functions. Text/icon
+   color while active is forced to --text rather than the raw tint though:
+   text-colored-as-background-tint against a background that's itself a
+   mix of that same tint reliably fails WCAG contrast (verified 2.2–2.3:1 in
+   the default theme, i.e. Lighthouse's aria-command-name/color-contrast
+   findings on issue #86) — --text is chosen per-theme specifically to
+   contrast against that theme's own backgrounds, so pairing it with a
+   tint-mixed background reliably does much better (4.96–6.2:1 here). The
+   idle-state 14%→8% mix below is the same fix applied to the untinted
+   text2-on-idle-background pairing (TX's own idle state measured 4.47:1,
+   just under the 4.5:1 minimum). */
 #tx-btn     { --btn-tint: var(--warn); }
 #listen-btn { --btn-tint: var(--green); }
 #record-btn { --btn-tint: var(--danger); }
 .node-controls .btn-icon {
-  background: color-mix(in srgb, var(--btn-tint) 14%, var(--bg3));
+  background: color-mix(in srgb, var(--btn-tint) 8%, var(--bg3));
   border-color: color-mix(in srgb, var(--btn-tint) 38%, var(--border));
 }
 .node-controls .btn-icon.btn-active {
@@ -5340,8 +5347,13 @@ function _txSetBtn(html, color) {
   var btn = document.getElementById('tx-btn');
   if (btn) {
     btn.innerHTML = html;
-    btn.style.color = color || '';
-    btn.classList.toggle('btn-active', color === 'var(--warn)');
+    /* color is also the active-state sentinel (see .node-controls .btn-icon
+       comment above) — the *displayed* text color while active is forced to
+       --text rather than the raw tint for contrast, but the sentinel check
+       itself still compares against the tint value passed in. */
+    var active = (color === 'var(--warn)');
+    btn.style.color = active ? 'var(--text)' : (color || '');
+    btn.classList.toggle('btn-active', active);
   }
 }
 
@@ -6210,9 +6222,13 @@ function _listenSetBtn(html, color, disabled) {
   var btn = document.getElementById('listen-btn');
   if (!btn) return;
   btn.innerHTML = html;
-  btn.style.color = color || '';
-  btn.disabled = !!disabled;
+  /* color is also the active-state sentinel (see .node-controls .btn-icon
+     comment above) — the *displayed* text color while active is forced to
+     --text rather than the raw tint for contrast, but the sentinel check
+     itself still compares against the tint value passed in. */
   var active = (color === 'var(--green)');
+  btn.style.color = active ? 'var(--text)' : (color || '');
+  btn.disabled = !!disabled;
   btn.classList.toggle('btn-active', active);
   var volRow = document.getElementById('listen-vol-row');
   if (volRow) volRow.style.opacity = active ? '1' : '0.4';


### PR DESCRIPTION
## Summary
- \`#tx-btn\` idle state measured 4.47:1 (just under the 4.5:1 AA minimum); reduced the idle-state tint mix from 14% to 8% — verified via a WCAG contrast calc across every bundled theme that this never regresses any theme's idle contrast, only improves or no-ops it.
- \`#listen-btn\` active ("Mute") state measured 2.3:1 — the root cause is coloring the active-state text as the raw \`--btn-tint\` value against a background that's itself a \`color-mix()\` of that same tint, which fails badly not just in the default theme but in nearly every one of the app's 20+ bundled themes (verified computationally). Fixed by forcing the *displayed* active-state text color to \`--text\` in \`_txSetBtn()\`/\`_listenSetBtn()\`, while keeping the existing tint value as the active-state sentinel those functions already compared against internally.

**Scope note:** \`#record-btn\` shares the identical mechanism but reads its active color from \`var(--red,#f85149)\` — a variable that's never actually defined in any theme block (pre-existing, unrelated bug). Left untouched here since it wasn't part of the reported audit and deserves its own look. A full contrast audit across all 20+ bundled color themes (many already fail this same check, unrelated to this change) is a separate, larger effort.

Closes #86

## Test plan
- [x] \`node --check\` on the extracted inline \`<script>\` content — syntax valid
- [x] WCAG contrast ratios recomputed by script for the default theme: tx-btn idle 4.47→4.99:1, listen-btn active 2.31→4.96:1 (both pass 4.5:1)
- [x] Confirmed the 14%→8% idle-mix change never lowers contrast for any of the app's 20+ themes
- [ ] Manual: open \`/status\`, arm TX and start Listen, confirm both buttons remain legible and their idle/active visual identity (amber/green tint) is still recognizable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wyz7aFAD7iFa1Ee4s4zjBQ