### PR TITLE
Preconnect to CDN origins to shorten render-blocking Leaflet CSS/JS

### DIFF
--- a/templates/status.html
+++ b/templates/status.html
@@ -7,6 +7,20 @@
 <title>HenWen Kiosk</title>
 <link id="dyn-favicon" rel="icon" type="image/x-icon" href="/static/favicon.ico">
 <script>(function(){var t=localStorage.getItem('henwen-theme')||localStorage.getItem('asl3ez-theme');if(t)document.documentElement.setAttribute('data-theme',t);})();</script>
+<!-- Warms up the connection to both CDN origins as early as possible in
+     <head> parsing — DNS/TCP/TLS handshake overlaps with the rest of the
+     page instead of only starting once the parser reaches each resource's
+     own tag below. Doesn't change load/execution order or timing of the
+     resources themselves (unlike defer/async, which risks breaking the
+     inline <script> at the bottom of body that uses L./satellite. as soon
+     as it runs), just shortens the connection-setup portion of the
+     render-blocking critical path Lighthouse's render-blocking-insight
+     flagged for leaflet.min.css/leaflet.min.js. crossorigin is required
+     for the browser to actually reuse the preconnected connection for a
+     CORS-fetched resource like these (font/style/script requests from a
+     third-party origin are anonymous-mode CORS requests by default here). -->
+<link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+<link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.min.css"/>
 <style>
 html[data-theme="midnight"] {


### PR DESCRIPTION
## Summary
- Lighthouse's \`render-blocking-insight\` flagged \`leaflet.min.css\`/\`leaflet.min.js\` (~210ms combined). The stylesheet link is already essentially first in \`<head>\`, so the remaining cost is connection setup (DNS/TCP/TLS) to a CDN origin the browser hasn't talked to yet.
- Added \`<link rel="preconnect">\` for both CDN origins (\`cdnjs.cloudflare.com\`, \`cdn.jsdelivr.net\`) at the top of \`<head>\`, so the handshake overlaps with the rest of head parsing instead of starting only once the parser reaches each resource's tag.

**Deliberately not using \`defer\`/\`async\`** on the script tags: the large inline \`<script>\` immediately following them at the bottom of \`<body>\` isn't wrapped in a \`DOMContentLoaded\`/\`load\` handler and may reference the Leaflet/\`satellite.js\` globals as soon as it runs — deferring the external scripts would very likely break that execution order. \`preconnect\` changes nothing about load order or timing of the resources themselves, only connection setup, so it carries no such risk.

Closes #90

## Test plan
- [x] stdlib \`HTMLParser\` tag-balance check — same (pre-existing, unrelated) single \`</link>\` warning as main, nothing newly introduced
- [ ] Manual: open \`/status\`, confirm the map/ISS layer still load and render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wyz7aFAD7iFa1Ee4s4zjBQ