### PR TITLE
Add meta description to the kiosk board

### DIFF
--- a/templates/status.html
+++ b/templates/status.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="csrf-token" content="{{ csrf_token() }}">
 <title>HenWen Kiosk</title>
+<meta name="description" content="HenWen live status board — AllStarLink node status, connections, map, and repeater activity.">
 <link id="dyn-favicon" rel="icon" type="image/x-icon" href="/static/favicon.ico">
 <script>(function(){var t=localStorage.getItem('henwen-theme')||localStorage.getItem('asl3ez-theme');if(t)document.documentElement.setAttribute('data-theme',t);})();</script>
 <!-- Warms up the connection to both CDN origins as early as possible in


### PR DESCRIPTION
## Summary
- Lighthouse's \`meta-description\` SEO audit failed — the kiosk board had no \`<meta name="description">\` tag. Added a short one.

Closes #92

## Test plan
- [x] One-line \`<meta>\` addition, no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wyz7aFAD7iFa1Ee4s4zjBQ