### PR TITLE
Tune Node/Map default row split closer to real content height (closes #101)

### DIFF
--- a/templates/status.html
+++ b/templates/status.html
@@ -368,8 +368,19 @@ html, body { height: 100%; background: var(--bg); color: var(--text);
    DASH_NON_GREEDY/dashSubtreeGreedy()), so Node still only claims what its
    content needs rather than stretching to the bottom of the window. The
    span below is only what's painted until the first board refresh — it must
-   stay in step with DASH_DEFAULT_TREE's node/map ratio (6/24), same
+   stay in step with DASH_DEFAULT_TREE's node/map ratio (10/24), same
    invariant as every other default here.
+   That ratio was tuned to the actual measured height of a typical
+   populated card (header + identity block + controls + volume row),
+   not picked arbitrarily -- a static guess far from what
+   dashFitNodeCard() computes on the first real refresh is itself a
+   layout-shift source (issue #101: a 6/24 guess against real content
+   came out closer to 10/24, a jump big enough to register as the
+   single largest contributor to a 0.774 Lighthouse CLS score). This
+   still won't be exact for every install (callsign/location length,
+   which buttons a viewer's role shows, etc. all vary), but it should
+   land close enough that the one guaranteed first-refresh reflow is
+   barely visible instead of a full card resizing under the viewer.
 
    The card itself carries no padding of its own — .card-header uses its
    ordinary shared style (padding/border-bottom) exactly like every other
@@ -381,7 +392,7 @@ html, body { height: 100%; background: var(--bg); color: var(--text);
    card's). All of the actual "pad the content, absorb the auto-fit
    leftover" work happens one level down, in .node-body, below. ── */
 .node-card {
-  grid-column: 1 / span 4; grid-row: 1 / span 6;
+  grid-column: 1 / span 4; grid-row: 1 / span 10;
   background: var(--bg2); border: 1px solid var(--border); border-radius: 10px;
   display: flex; flex-direction: column; overflow: hidden; min-height: 0;
 }
@@ -758,7 +769,7 @@ html, body { height: 100%; background: var(--bg); color: var(--text);
 .mesh-text { font-size: 0.78rem; color: var(--text); word-wrap: break-word; margin-top: 1px; }
 
 /* ── Map ── */
-.map-card { grid-column: 1 / span 4; grid-row: 7 / span 18; min-height: 0;
+.map-card { grid-column: 1 / span 4; grid-row: 11 / span 14; min-height: 0;
   background: var(--bg2); border: 1px solid var(--border); border-radius: 10px;
   display: flex; flex-direction: column; overflow: hidden; }
 #map { flex: 1; background: #0d1117; }
@@ -6881,7 +6892,7 @@ var DASH_DEFAULT_TREE = {
      board refresh (and rewrites it on resize). Keep it in step with
      .node-card/.map-card's stylesheet row spans, which are what's painted
      until that first measurement lands. */
-  a: {type: 'split', dir: 'row', ratio: 6 / 24,
+  a: {type: 'split', dir: 'row', ratio: 10 / 24,
     a: {type: 'leaf', id: 'node'},
     b: {type: 'leaf', id: 'map'}
   },


### PR DESCRIPTION
## Problem
Lighthouse flagged a Cumulative Layout Shift of **0.774** on `henwen.ironicsandwich.com` (issue #101) — the worst-scoring metric in the run. The largest single culprit was `#content-area` (score 0.586), with `.connected-card` (which spans all 24 grid rows) registering the same shift three separate times as a downstream effect.

## Root cause
The Node/Map column's row split is deliberately re-measured against real content on every board refresh (`dashFitNodeCard()` → `dashApply()`), per the extensive existing comments on `.node-card`. That's by design — the card is meant to fit its actual content exactly. But the *static* CSS/JS default it starts from before the first measurement (`grid-row: 1 / span 6`, i.e. 6/24 of the grid) was a rough guess, not derived from real rendered content. Since `.content-area`'s rows are `fr` tracks shared across the whole grid, the jump from that static guess to the real fitted value on the very first `/api/status/board` response reflows every full-height card in the grid — exactly the CLS pattern in the report.

## Fix
Using the actual pixel measurements captured in the Lighthouse run's own `fullPageScreenshot` node data (`#node-info` + `#node-controls` + `#listen-vol-row`'s combined rendered span, plus the card header/padding/border CSS values), the typical fitted content height works out to roughly **10/24** rows, not 6/24. Updated the three places this ratio has to stay in sync (per the existing comment's own stated invariant):
- `.node-card { grid-row: 1 / span 6 }` → `span 10`
- `.map-card { grid-row: 7 / span 18 }` → `11 / span 14` (still sums to 24)
- `DASH_DEFAULT_TREE`'s node/map `ratio: 6 / 24` → `10 / 24`

`dashFitNodeCard()` still measures and corrects this per-install exactly as before — this change only narrows the gap between what's painted before that first measurement and what it settles on, so the one guaranteed first-refresh reflow is far less visible. It won't be pixel-perfect for every install (callsign/location length, which role-gated buttons a viewer sees, etc. all vary the real content height), but it's a large, well-grounded improvement over the previous guess.

## Testing
- Full pytest suite: 490 passed.
- `node --check` on all three inline `<script>` blocks: syntax OK.
- No JS logic changed — this is purely a static-default tuning of numbers the existing auto-fit system already treats as a starting point, so there's no risk to the drag/resize/fold dashboard engine itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wyz7aFAD7iFa1Ee4s4zjBQ