### PR TITLE
Enlarge touch targets: map markers and favorites Connect/Monitor buttons (closes #102)

### DIFF
--- a/templates/status.html
+++ b/templates/status.html
@@ -846,7 +846,11 @@ html, body { height: 100%; background: var(--bg); color: var(--text);
 .fav-call:hover { text-decoration: underline; }
 .fav-loc  { font-size: 0.67rem; color: var(--text2); overflow: hidden;
   text-overflow: ellipsis; white-space: nowrap; }
-.fav-actions { display: flex; flex-direction: column; gap: 3px; align-items: stretch; width: fit-content; }
+/* gap bumped 3px -> 6px alongside .sb-btn's taller padding below (issue #102):
+   Lighthouse's target-size audit checks clickable space between neighbors as
+   well as each target's own size, and the stacked Connect/Monitor pair here
+   was failing both. */
+.fav-actions { display: flex; flex-direction: column; gap: 6px; align-items: stretch; width: fit-content; }
 /* min-width/min-height/padding push the actual click target to ~24x24px
    (was ~11x10px, failing Lighthouse's target-size audit both on its own
    size and its clearance from the callsign link/Disconnect button next to
@@ -894,10 +898,16 @@ html, body { height: 100%; background: var(--bg); color: var(--text);
 .chat-composer input:focus { outline: none; border-color: var(--accent); }
 
 
-/* ── Status-board action buttons ── */
+/* ── Status-board action buttons ──
+   Vertical padding bumped 3px -> 6px (issue #102): at 0.68rem/3px this
+   rendered at ~20px tall, under Lighthouse's 24px target-size minimum,
+   everywhere this class is used (favorites list, Connected Nodes, node
+   search results). Horizontal padding is untouched — width was never
+   the flagged dimension, and most of these buttons already sit well past
+   24px wide from their own label text alone. */
 .sb-btn {
   font-size: 0.68rem; font-weight: 600; letter-spacing: .03em;
-  padding: 3px 8px; border-radius: 4px; border: 1px solid; cursor: pointer;
+  padding: 6px 8px; border-radius: 4px; border: 1px solid; cursor: pointer;
   white-space: nowrap; transition: all .15s; flex-shrink: 0;
 }
 .sb-btn.connect    { background: rgba(63,185,80,.08);  border-color: rgba(63,185,80,.3);  color: var(--green); }
@@ -2461,13 +2471,45 @@ function starSize() {
   return [s, s];
 }
 
+/* WCAG 2.2/Lighthouse's target-size minimum is 24x24 CSS px. Several of the
+   map glyphs below are deliberately smaller than that at typical zoom so the
+   map doesn't turn into a wall of oversized dots (see pinSize()/
+   aprsIconSize()'s own halved-then-halved-again history) — Lighthouse
+   flagged exactly this on henwen.ironicsandwich.com (issue #102): a
+   pinSize() teardrop at z<=6 renders ~10.8x16.2px.
+   Rather than growing the visible glyph, wrap it in a flex-centered box
+   padded up to at least 24x24 — only the *clickable* divIcon element grows;
+   the SVG inside keeps its original pixel size and visual weight on the
+   map. Padding is symmetric, so each axis's anchor just needs to shift by
+   half of whatever got added to that axis to keep pointing at the exact
+   same map coordinate as before (this is exact, not approximate: the
+   glyph's own top/left edge moves by padY/padX, so any anchor coordinate
+   measured from that edge — a center at s/2 or a pin tip at the full
+   height — moves by the same padY/padX). */
+var MAP_MIN_TARGET_PX = 24;
+function padMarkerIcon(svg, w, h) {
+  var boxW = Math.max(w, MAP_MIN_TARGET_PX), boxH = Math.max(h, MAP_MIN_TARGET_PX);
+  return {
+    html: '<div style="width:' + boxW + 'px;height:' + boxH + 'px;display:flex;' +
+          'align-items:center;justify-content:center">' + svg + '</div>',
+    size: [boxW, boxH],
+    padX: (boxW - w) / 2,
+    padY: (boxH - h) / 2
+  };
+}
+
 function makeIcon(color, opacity) {
   var s  = pinSize();
   var op = (opacity == null) ? 0.9 : opacity;
   var svg = '<svg xmlns="http://www.w3.org/2000/svg" width="' + s[0] + '" height="' + s[1] +
     '" viewBox="0 0 20 30"><path d="M10 0C4.5 0 0 4.5 0 10c0 7.5 10 20 10 20S20 17.5 20 10C20 4.5 15.5 0 10 0z"' +
     ' fill="' + color + '" opacity="' + op + '"/><circle cx="10" cy="10" r="4" fill="white" opacity="' + op + '"/></svg>';
-  return L.divIcon({ html:svg, iconSize:s, iconAnchor:[s[0]/2,s[1]], popupAnchor:[0,-s[1]], className:'' });
+  var p = padMarkerIcon(svg, s[0], s[1]);
+  /* Anchor is the pin's tip (bottom-center of the original glyph), so the y
+     coordinate shifts by the full padY (top padding pushes the whole glyph
+     down), not padY/2. */
+  var anchorY = s[1] + p.padY;
+  return L.divIcon({ html:p.html, iconSize:p.size, iconAnchor:[p.size[0]/2, anchorY], popupAnchor:[0,-anchorY], className:'' });
 }
 
 /* Global (blue) activity pins start bright and mute toward a dim blue-gray
@@ -2506,7 +2548,10 @@ function makeStarIcon(color) {
   var svg = '<svg xmlns="http://www.w3.org/2000/svg" width="' + s[0] + '" height="' + s[1] +
     '" viewBox="0 0 32 32"><polygon points="16,2 20,12 31,12 22,19 25,30 16,23 7,30 10,19 1,12 12,12"' +
     ' fill="' + color + '" stroke="white" stroke-width="1.5" opacity="0.95"/></svg>';
-  return L.divIcon({ html:svg, iconSize:s, iconAnchor:[s[0]/2,s[1]/2], popupAnchor:[0,-s[1]/2], className:'' });
+  var p = padMarkerIcon(svg, s[0], s[1]);
+  /* Center-anchored, so the anchor is just the padded box's own center —
+     centering a symmetric pad never moves it. */
+  return L.divIcon({ html:p.html, iconSize:p.size, iconAnchor:[p.size[0]/2,p.size[1]/2], popupAnchor:[0,-p.size[1]/2], className:'' });
 }
 
 /* Plain filled circle — deliberately not the node teardrop pin or the
@@ -2519,7 +2564,8 @@ function makeAprsIcon(color, opacity) {
   var svg = '<svg xmlns="http://www.w3.org/2000/svg" width="' + d + '" height="' + d +
     '" viewBox="0 0 20 20"><circle cx="10" cy="10" r="8" fill="' + (color || '#a855f7') +
     '" stroke="white" stroke-width="1.5" opacity="' + op + '"/></svg>';
-  return L.divIcon({ html:svg, iconSize:[d,d], iconAnchor:[d/2,d/2], popupAnchor:[0,-d/2], className:'' });
+  var p = padMarkerIcon(svg, d, d);
+  return L.divIcon({ html:p.html, iconSize:p.size, iconAnchor:[p.size[0]/2,p.size[1]/2], popupAnchor:[0,-p.size[1]/2], className:'' });
 }
 
 /* ── APRS-IS map layer (optional, toggled from the map controls) ──
@@ -2766,7 +2812,8 @@ function makeIssIcon() {
     '<rect x="9" y="9" width="6" height="6" fill="' + ISS_PASS_COLOR + '" stroke="none"/>' +
     '<path d="M9 12H4M20 12h-5M4 8v8M20 8v8M9 9V4M9 20V15M15 9V4M15 20V15"/>' +
     '</svg>';
-  return L.divIcon({ html: svg, iconSize: [d, d], iconAnchor: [d / 2, d / 2], popupAnchor: [0, -d / 2], className: '' });
+  var p = padMarkerIcon(svg, d, d);
+  return L.divIcon({ html: p.html, iconSize: p.size, iconAnchor: [p.size[0] / 2, p.size[1] / 2], popupAnchor: [0, -p.size[1] / 2], className: '' });
 }
 
 function _issNormLon(lon) {


### PR DESCRIPTION
## Problem
Lighthouse's `target-size` accessibility audit failed (score 0) on `henwen.ironicsandwich.com` (issue #102), flagging two groups of undersized/too-close click targets:

1. Leaflet map markers (`div.leaflet-marker-icon`): ~10.8×16.2px, need ≥24×24px, and only ~2.6-5.4px of clearance from neighboring markers.
2. Favorites list Connect/Monitor buttons (`.sb-btn` inside `.fav-actions`): 63.8×20px — height is 20px (need 24px), and the stacked pair only had ~22px of vertical space between them.

## Fix

**Map markers**: added a `padMarkerIcon()` helper shared by all four marker-icon factories (`makeIcon` — ASL teardrop pins, `makeStarIcon` — hosted-node star, `makeAprsIcon` — APRS circles, `makeIssIcon` — ISS glyph). It wraps each marker's SVG in a flex-centered `<div>` padded up to at least 24×24, so only the *clickable* divIcon box grows — the visible glyph keeps its exact original pixel size and visual weight on the map, nothing looks different. Since the padding is symmetric, each factory's `iconAnchor` is shifted by exactly the padding added on that axis (full `padY` for `makeIcon`'s bottom-anchored pin tip, half of each axis for the three center-anchored glyphs), so every marker still points at the same map coordinate it did before — this is exact math, not a visual approximation.

**Favorites buttons**: `.sb-btn`'s vertical padding went from 3px to 6px (~20px → ~26px tall), and `.fav-actions`'s gap from 3px to 6px. `.sb-btn` is shared across the favorites list, Connected Nodes, and node search results, so this fixes the same undersized-button pattern everywhere it's used, not just the one instance Lighthouse happened to sample.

## Testing
- Full pytest suite: 490 passed.
- `node --check` on the main inline `<script>` block: syntax OK.
- Anchor-shift math verified by hand for both the bottom-anchored (`makeIcon`) and center-anchored (the other three) cases — see the inline comments explaining why each uses a different offset.
- Could not visually verify marker positioning against a live map (no live Asterisk/board data in this environment), but the anchor math is a straightforward, mechanical adjustment with no behavioral branching, and doesn't touch any of the map's zoom/pan/rendering logic itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wyz7aFAD7iFa1Ee4s4zjBQ