### PR TITLE
Fix map pin's Connect/Monitor button getting stuck after a click

### DIFF
--- a/templates/status.html
+++ b/templates/status.html
@@ -4720,6 +4720,18 @@ function sbToast(msg, ok) {
 
 async function sbConnect(localNode, remoteNode, btn, permanent, monitor) {
   var label = monitor ? 'Monitor' : 'Connect';
+  /* A map pin's popup is the one caller of this function whose button lives
+     inside content updateMap() refuses to touch while any popup is open
+     (see the popupopen/popupclose handlers in initMap()) -- that guard
+     exists so a background poll can't yank the popup out from under a user
+     reading it, but it means a Connect/Monitor click *inside* that same
+     popup never gets its disabled "..." state replaced by anything: nothing
+     else ever rebuilds that popup while it's still open. Left alone, the
+     button sits there disabled and unresponsive forever (issue #114) --
+     read the .leaflet-popup ancestor here (rather than always closing
+     whatever's open) so a Connect click from the Favorites sidebar doesn't
+     also snap shut an unrelated map popup the user still has open. */
+  var fromMapPopup = !!(btn && typeof btn.closest === 'function' && btn.closest('.leaflet-popup'));
   if (btn) { btn.disabled = true; btn.textContent = '…'; }
   try {
     var r = await apiFetch('/api/status/connect', {
@@ -4730,6 +4742,13 @@ async function sbConnect(localNode, remoteNode, btn, permanent, monitor) {
     var d = await r.json();
     if (r.ok && d.ok) {
       sbToast((monitor ? 'Monitoring' : 'Connecting to') + ' ' + remoteNode + '…', true);
+      /* Close it now rather than waiting for the user to dismiss it
+         themselves -- that's what lets updateMap()'s deferred re-render
+         (queued via _mapDirty) run immediately instead of staying stuck
+         behind this same popup, so the pin reflects the new state on the
+         very next board refresh instead of whenever the popup happens to
+         close on its own. */
+      if (fromMapPopup && typeof _map !== 'undefined' && _map) _map.closePopup();
       setTimeout(refreshBoard, 1500);
     } else if (r.status === 401) {
       if (btn) { btn.disabled = false; btn.textContent = label; }


### PR DESCRIPTION
## Summary

- Closes #114. Clicking Connect or Monitor in a kiosk map pin's popup leaves the button permanently disabled showing "…" — it never becomes clickable or shows anything else, reading as a broken "..." button.

**Root cause:** `updateMap()` deliberately defers rebuilding markers/popups while any Leaflet popup is open (see the `popupopen`/`popupclose` handlers in `initMap()`) — that guard exists so a background board poll can't yank a popup out from under someone reading it. But the activity-pin popup is also where the Connect/Monitor buttons live, and clicking one doesn't close the popup. `sbConnect()` sets the clicked button to a disabled `…` loading state on click and relies entirely on that same deferred rebuild to replace it afterward. Since the popup never closes on its own, the rebuild never runs, and the button is stuck forever.

This also explains the related report in the issue thread (clicking to another pin then back showing no buttons, or Connect again "in error"): the rebuild stays deferred for as long as the user keeps hopping from one popup straight into another (`popupclose` then `popupopen` fire back-to-back, so the deferred check never actually observes a moment with no popup open), so a pin whose Connect click got stuck this way can go on showing stale content well after the fact.

**Fix:** `sbConnect()` now closes the popup itself on a successful connect/monitor — but only when the clicked button is actually inside one (checked via `closest('.leaflet-popup')`), so a Connect click from the Favorites sidebar doesn't also snap shut an unrelated map popup the user still has open elsewhere. Closing it lets the deferred rebuild run immediately, so the pin reflects the new state on the next board refresh instead of waiting on whichever popup happens to close on its own.

## Test plan

- [x] `./venv/bin/pytest` — 625 passed (pure frontend change, no backend touched)
- [x] `node --check` on the extracted inline `<script>` block — syntax OK
- [x] Deploying to `/opt/HenWen` for a live check: click Connect/Monitor from a map pin's popup and confirm it no longer sticks on "…"

🤖 Generated with [Claude Code](https://claude.com/claude-code)