### PR TITLE
Generate a random SECRET_KEY on install (closes #115)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -199,7 +199,35 @@ if [ -f /etc/systemd/system/asl3-rpt-editor.service ]; then
     rm -f /etc/systemd/system/asl3-rpt-editor.service
 fi
 
-cp "$INSTALL_DIR/HenWen.service" /etc/systemd/system/
+SERVICE_FILE_DEST="/etc/systemd/system/${SERVICE_NAME}.service"
+
+# Every checked-in HenWen.service ships the same placeholder
+# SECRET_KEY=henwen-change-me-in-production -- a plain `cp` would leave
+# every fresh install signing session cookies with that identical,
+# publicly-known key until an admin happens to notice the Dashboard's
+# warning and rotates it by hand (issue #115). Generate a real random one
+# here instead, the same way the in-app rotation route does
+# (secrets.token_hex(32)), so a fresh install is secure by default. If
+# this is a reinstall over an already-rotated key, preserve that existing
+# key rather than clobbering it back to the placeholder -- same
+# preserve-across-reinstall reasoning as henwen.db above, and it avoids
+# silently invalidating every logged-in session on a routine reinstall.
+PREV_SECRET_KEY=""
+if [ -f "$SERVICE_FILE_DEST" ]; then
+    PREV_SECRET_KEY=$(sed -n 's/^Environment="\?SECRET_KEY=\([^"]*\)"\?[[:space:]]*$/\1/p' "$SERVICE_FILE_DEST" | head -1)
+fi
+
+cp "$INSTALL_DIR/HenWen.service" "$SERVICE_FILE_DEST"
+
+if [ -n "$PREV_SECRET_KEY" ] && [ "$PREV_SECRET_KEY" != "henwen-change-me-in-production" ]; then
+    echo "      Preserving existing SECRET_KEY from previous install."
+    NEW_SECRET_KEY="$PREV_SECRET_KEY"
+else
+    echo "      Generating a random SECRET_KEY for this install."
+    NEW_SECRET_KEY=$(python3 -c "import secrets; print(secrets.token_hex(32))")
+fi
+sed -i "s|^Environment=\"\?SECRET_KEY=.*|Environment=\"SECRET_KEY=${NEW_SECRET_KEY}\"|" "$SERVICE_FILE_DEST"
+
 systemctl daemon-reload
 
 # ── Cap systemd journal size ──────────────────────────────


### PR DESCRIPTION
## Summary
Answers both questions from #115:

- **Is SECRET_KEY something a user should see?** It already is — `app.py`/`henwen-manager.html` (from an earlier PR) detect a default key, warn on the Dashboard, and offer a one-click rotation in Manager > Settings. No change needed there.
- **Should a new key be generated along with the install script?** Not currently — `install.sh` just `cp`s the checked-in `HenWen.service`, so every fresh install ships the exact same `SECRET_KEY=henwen-change-me-in-production` placeholder until an admin notices the warning and rotates it by hand. This PR fixes that.

`install.sh` now:
- Generates a real random `SECRET_KEY` at install time (`secrets.token_hex(32)`, same shape the in-app rotation route already produces) and writes it into the copied unit file.
- Preserves an already-rotated key across a reinstall instead of silently clobbering it back to the shared placeholder (mirrors the existing `henwen.db`-preservation reasoning, and avoids invalidating every logged-in session on a routine reinstall).

Not a runtime file, so nothing to deploy live for this change — it only affects future/re-installs. Verified with `bash -n` and by simulating the sed extraction/substitution logic against copies of `HenWen.service` in both scenarios (fresh install, reinstall over a custom key); per project convention `install.sh` itself is never executed in this environment.

## Test plan
- [x] `bash -n install.sh`
- [x] Simulated fresh-install path against a temp copy of `HenWen.service` — placeholder replaced with a 64-char random hex key
- [x] Simulated reinstall path with a pre-existing custom key — key preserved, not regenerated
- [ ] Manual: run `install.sh` on a real box and confirm `Environment="SECRET_KEY=..."` in `/etc/systemd/system/HenWen.service` is random, not the placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)