### PR TITLE
Restrict SECRET_KEY rotation to superuser/owner

### DIFF
--- a/app.py
+++ b/app.py
@@ -10718,6 +10718,8 @@ def api_ws_audio_apply():
 
 @app.route("/api/settings/secret_key")
 def api_get_secret_key():
+    if session.get('role') not in ('superuser', 'owner'):
+        return jsonify({"error": "Superuser access required"}), 403
     return jsonify({
         "is_default":         SECRET_KEY in DEFAULT_SECRET_KEYS,
         "service_file":       SERVICE_FILE_PATH,
@@ -10813,6 +10815,9 @@ def api_set_secret_key():
     sent before the restart is triggered (from a background thread) so the
     browser actually receives it before the worker process is replaced.
     """
+    if session.get('role') not in ('superuser', 'owner'):
+        return jsonify({"error": "Superuser access required"}), 403
+
     data    = request.json or {}
     new_key = str(data.get("secret_key", "")).strip()
 

--- a/templates/henwen-manager.html
+++ b/templates/henwen-manager.html
@@ -2821,7 +2821,7 @@ sudo bash /opt/HenWen/tx-spike/apply.sh</pre>
       </div>
     </div>
 
-    <div class="card">
+    <div class="card" id="secret-key-settings-card">
       <div class="card-header"><h2>Flask Secret Key</h2></div>
       <div class="card-body">
         <p class="muted" style="margin-bottom:14px">
@@ -3389,8 +3389,13 @@ async function refreshDashboard() {
 
   document.getElementById('dash-ts').textContent = 'Updated: ' + new Date().toLocaleTimeString();
 
+  // Only superuser/owner can act on this (rotating SECRET_KEY is gated the
+  // same way now — see applyRoleNav()'s secretKeyCard), so admins don't get
+  // a warning pointing at a Settings card they can't see, same reasoning as
+  // checkForUpdate()'s own role check.
   var secretWarnEl = document.getElementById('dash-secret-warn');
-  secretWarnEl.innerHTML = d.secret_key_is_default
+  var isSuperForWarn = (window._henwenRole === 'superuser' || window._henwenRole === 'owner');
+  secretWarnEl.innerHTML = (d.secret_key_is_default && isSuperForWarn)
     ? '<div class="alert alert-warn">Still using the default SECRET_KEY. '
       + '<a href="javascript:void(0)" onclick="showPage(\'settings\')" style="color:inherit;text-decoration:underline">Change it in Settings</a>.</div>'
     : '';
@@ -6572,6 +6577,11 @@ async function applyRoleNav() {
      without shell access to fix it back. */
   var portsCard = document.getElementById('ports-settings-card');
   if (portsCard) portsCard.style.display = isSuper ? '' : 'none';
+  /* Only superuser/owner can rotate SECRET_KEY (matches the backend gate
+     on /api/settings/secret_key) — same unit-file-write-plus-restart
+     mechanism as ports above, and it force-logs-out every session. */
+  var secretKeyCard = document.getElementById('secret-key-settings-card');
+  if (secretKeyCard) secretKeyCard.style.display = isSuper ? '' : 'none';
   /* Recording Settings and Stream Relay are owner-only — matches the
      backend's explicit role==='owner' check on both config routes. */
   var isOwnerRole = (role === 'owner');


### PR DESCRIPTION
## Summary
Follow-up from #115 (which added install-time random-key generation in #124). Discussed in that thread: `/api/settings/secret_key` (GET+POST) had no explicit role check, so it fell through to `check_auth()`'s generic admin+ default — meaning a plain `admin` account could view whether the key was still default *and* force-restart the service (invalidating every logged-in session, including superuser/owner ones) by rotating it.

This is the same unit-file-write-plus-restart mechanism as `/api/settings/ports`, which is already explicitly gated to `role in ('superuser', 'owner')`. This PR brings SECRET_KEY in line with that instead of going all the way to owner-only — owner-only in this codebase is reserved for things touching a third-party secret (webhooks, stream keys, MQTT PSK) or the highest-blast-radius infra toggles, not internal service-config actions a superuser already handles elsewhere (raw rpt.conf editor, Launch Updater, ports).

- `api_get_secret_key`/`api_set_secret_key`: explicit `role not in ('superuser', 'owner')` → 403, matching `api_set_ports`.
- Manager UI: the "Flask Secret Key" Settings card is now hidden for plain admins (`applyRoleNav()`, same `isSuper` gate as the Ports card).
- Dashboard's "Still using the default SECRET_KEY" warning bar is now also gated to superuser/owner — an admin who can't act on it shouldn't see a dead-end link to a card they can't see, same reasoning `checkForUpdate()` already applies to the update-available bar.

## Test plan
- [x] `./venv/bin/pytest` — 636 passed
- [x] Deployed to `/opt/HenWen` and restarted `HenWen` — service active, `/status` returns 200
- [ ] Manual: confirm a plain `admin` account no longer sees the Settings card / Dashboard warning, and gets 403 hitting the route directly; superuser/owner unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RyXFaGsPQ7TCDWDkDXokV