### PR TITLE
Reset Listen button when the server closes the audio stream cleanly

### DIFF
--- a/templates/status.html
+++ b/templates/status.html
@@ -6955,8 +6955,26 @@ function _doStartListenMSE(audio, node) {
         function pump() {
           if (ctrl.signal.aborted) return;
           reader.read().then(function(result) {
-            if (result.done || ctrl.signal.aborted) {
+            if (ctrl.signal.aborted) {
               try { ms.endOfStream(); } catch(e) {}
+              return;
+            }
+            if (result.done) {
+              /* Server closed the stream cleanly -- e.g. the broadcast's
+                 GeneratorExit/shutdown sentinel path in api_audio_stream()
+                 fires when Asterisk or HenWen itself restarts out from
+                 under a listener. That's not a fetch error (no exception,
+                 nothing for the catch() below to see), so it needs the same
+                 reset-and-reconnect handling here or the button is left
+                 stuck showing "Mute" with nothing actually playing
+                 (issue #116). */
+              try { ms.endOfStream(); } catch(e) {}
+              console.warn('[AUDIO] stream ended (server closed connection)');
+              if (_listenActive) {
+                _listenActive = false;
+                _listenSetBtn('Reconnecting...', 'var(--text2)', true);
+                setTimeout(function() { if (!_listenActive) _startListen(); }, 3000);
+              }
               return;
             }
             var nowA = _now();


### PR DESCRIPTION
## Summary
- Fixes #116: the kiosk Listen/Mute button got stuck showing "Mute" after an Asterisk or HenWen restart interrupted the stream, requiring a manual Mute→Listen cycle to resume.
- Root cause: `api_audio_stream()`'s `generate()` closes the HTTP response cleanly (its loop returns normally on the shutdown sentinel, no exception) when the broadcast tears down — e.g. on a server restart. The MSE listen path's `pump()` only handled that as `result.done`, calling `ms.endOfStream()` and stopping without resetting `_listenActive` or the button, so nothing was actually playing anymore even though the UI still showed the active "Mute" state.
- Fix: treat a clean `result.done` the same way the adjacent fetch-error `catch()` block already does — reset state, flip the button back, and auto-reconnect after 3s.
- The low-latency WebSocket path (`onclose`) and the non-MSE `<audio src>` fallback path (`onended`) already reset the button correctly on their own disconnect events; this was specifically an MSE-path gap.

## Test plan
- [x] Verified the edited script block parses cleanly (`node --check`)
- [ ] Live verification: start Listen on a node, restart HenWen (or Asterisk) mid-stream, confirm the button auto-recovers to "Listen"/reconnects instead of staying stuck on "Mute"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RyXFaGsPQ7TCDWDkDXokV