### PR TITLE
Flag rpt.conf keys that look like typos of known settings

### DIFF
--- a/app.py
+++ b/app.py
@@ -5103,6 +5103,31 @@ _BOOL_VALUES   = frozenset(["0", "1", "yes", "no", "true", "false", "on", "off"]
 _NONEMPTY_TYPES = frozenset(["nonempty", "id_sound", "dtmf_char", "identifier"])
 
 
+def find_key_typos(settings):
+    """
+    Flag active (uncommented) keys in a stanza's effective settings that
+    aren't recognized by SETTINGS_SCHEMA but closely resemble one that is —
+    e.g. 'totimer' typed instead of 'totime' (issue #117: a live
+    'totimer = 300000' line that Asterisk's config parser silently ignores,
+    since app_rpt never looks up an unrecognized directive name — there's no
+    "unknown key" warning surfaced anywhere. The node's real totime stayed
+    at its inherited/default value the whole time, and the owner had no way
+    to see why toggling the Manager UI's totime field appeared to do
+    nothing: they were never looking at the setting actually in effect).
+    Cutoff 0.82 is deliberately strict — SETTINGS_SCHEMA doesn't claim to be
+    an exhaustive list of every valid app_rpt directive, so this is a soft
+    "did you mean" nudge, not a validation error, and never blocks a save.
+    """
+    warnings = []
+    for key, info in settings.items():
+        if key in SETTINGS_SCHEMA or info.get("commented"):
+            continue
+        match = difflib.get_close_matches(key, SETTINGS_SCHEMA.keys(), n=1, cutoff=0.82)
+        if match:
+            warnings.append({"key": key, "value": info.get("value", ""), "likely": match[0]})
+    return warnings
+
+
 def validate_setting(key, value):
     """Return None if value is acceptable for key, otherwise an error string."""
     schema = SETTINGS_SCHEMA.get(key)
@@ -5578,7 +5603,8 @@ def api_get_node_conf(node):
                 break
     usage     = get_node_template_usage(content)
     templates = [t for t, nodes in usage.items() if node in nodes]
-    return jsonify({"node": node, "settings": settings, "templates": templates})
+    return jsonify({"node": node, "settings": settings, "templates": templates,
+                    "key_typo_warnings": find_key_typos(settings)})
 
 
 @app.route("/api/conf/templates")
@@ -5611,7 +5637,8 @@ def api_get_template_conf(name):
         return jsonify({"error": f"Template [{name}] not found in rpt.conf"}), 404
     settings = parse_stanza_settings(content, name)
     usage    = get_node_template_usage(content)
-    return jsonify({"template": name, "settings": settings, "used_by": usage.get(name, [])})
+    return jsonify({"template": name, "settings": settings, "used_by": usage.get(name, []),
+                    "key_typo_warnings": find_key_typos(settings)})
 
 
 @app.route("/api/conf/macros")

--- a/templates/henwen-manager.html
+++ b/templates/henwen-manager.html
@@ -4060,6 +4060,21 @@ async function loadStanzaEditor(sectionName, elId, apiUrl, loadingLabel, fallbac
   var s    = r.data.settings || {};
   var html = '';
 
+  // Active keys that don't match any known rpt.conf directive but closely
+  // resemble one (e.g. 'totimer' instead of 'totime', issue #117) — these
+  // are silently ignored by Asterisk, so a value here that looks like it's
+  // controlling a setting actually isn't doing anything at all.
+  var typoWarnings = r.data.key_typo_warnings || [];
+  if (typoWarnings.length) {
+    html += '<div class="alert alert-warn" style="margin-bottom:12px">'
+          + typoWarnings.map(function(w) {
+              return '&#9888; <code>' + esc(w.key) + ' = ' + esc(w.value) + '</code> is not a recognized '
+                   + 'rpt.conf setting &mdash; Asterisk ignores it entirely. Did you mean '
+                   + '<code>' + esc(w.likely) + '</code>?';
+            }).join('<br>')
+          + '</div>';
+  }
+
   NODE_SECS.forEach(function(sec, i) {
     var open = i === 0 ? ' open' : '';
     html += '<div class="card" style="margin-bottom:12px">'

--- a/tests/test_rpt_conf_parser.py
+++ b/tests/test_rpt_conf_parser.py
@@ -160,6 +160,35 @@ class TestUpdateSettingInContent:
         assert app._parse_kv_lines(stanzas["b"]["lines"])["foo"]["value"] == "1"
 
 
+class TestFindKeyTypos:
+    def test_flags_totimer_as_likely_totime(self):
+        """issue #117: 'totimer = 300000' (an extra trailing 'r') is not a
+        real app_rpt directive, so Asterisk silently ignores it -- the node
+        keeps whatever totime it inherits/defaults to, with no indication
+        anywhere that the override the owner thinks is active isn't."""
+        settings = app.parse_stanza_settings(
+            "[628280](node-main)\ntotimer = 300000\n", "628280")
+        warnings = app.find_key_typos(settings)
+        assert warnings == [{"key": "totimer", "value": "300000", "likely": "totime"}]
+
+    def test_recognized_key_is_not_flagged(self):
+        settings = app.parse_stanza_settings("[x]\ntotime = 180000\n", "x")
+        assert app.find_key_typos(settings) == []
+
+    def test_commented_unknown_key_is_not_flagged(self):
+        # A disabled/commented line has no effect on Asterisk either way,
+        # so there's nothing here to silently be going wrong.
+        settings = app.parse_stanza_settings("[x]\n;totimer = 300000\n", "x")
+        assert app.find_key_typos(settings) == []
+
+    def test_unrelated_unknown_key_is_not_flagged(self):
+        # SETTINGS_SCHEMA isn't an exhaustive list of every valid app_rpt
+        # directive, so a key that isn't a close match to anything known
+        # must not be flagged as a typo.
+        settings = app.parse_stanza_settings("[x]\nsome_custom_directive = 1\n", "x")
+        assert app.find_key_typos(settings) == []
+
+
 class TestValidateSetting:
     def test_unknown_key_always_passes(self):
         assert app.validate_setting("some_totally_unknown_key", "anything") is None


### PR DESCRIPTION
## Summary

- Fixes #117's underlying confusion: node 628280's rpt.conf had an active `totimer = 300000` line (an extra trailing `r`), which is not a real app_rpt directive — Asterisk's config parser just ignores keys it doesn't itself look up, so this had zero effect. The node's actual `totime` kept coming from whatever it inherits/defaults to, so toggling the Manager UI's `totime` field for that node appeared to do nothing, because the owner was never looking at the setting that was actually in effect.
- I confirmed HenWen's own parser is *not* mis-reading `totimer` as `totime` (regex captures the full key), and the separate `;totime = 180000` line visible in the issue's screenshot is boilerplate from ASL3's own stock rpt.conf example for a second, fully-commented (inactive) node — HenWen attributes it to node 628280's own stanza, which actually matches how Asterisk's comment-oblivious config parser would read it too (no real header in between), so that part isn't a parsing bug. The real, actionable gap is that a typo'd, non-functional key had no visibility anywhere in the UI.
- `find_key_typos()` (app.py) flags active (uncommented) keys in a stanza's effective settings that aren't in `SETTINGS_SCHEMA` but are a close match (`difflib.get_close_matches`, cutoff 0.82) to one that is. Wired into `/api/conf/node/<node>` and `/api/conf/template/<name>` as `key_typo_warnings`; the Manager UI renders these as a warning banner above the node/template settings editor.
- Soft nudge only — never blocks a save, since `SETTINGS_SCHEMA` isn't an exhaustive list of every valid app_rpt directive.

## Test plan
- [x] `./venv/bin/pytest` — 640 passed, including new `TestFindKeyTypos` cases (flags `totimer`→`totime`, doesn't flag known/commented/unrelated-unknown keys)
- [x] `python3 -m py_compile app.py`
- [x] Deployed to live `/opt/HenWen`, restarted `HenWen.service`, confirmed clean startup in `journalctl` and `/status` still serving 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RyXFaGsPQ7TCDWDkDXokV