### PR TITLE
Fix stale keyed-activity bar / tab dot after tab regains focus (issue #125)

### DIFF
--- a/templates/status.html
+++ b/templates/status.html
@@ -8143,6 +8143,23 @@ setInterval(fetchNets,       60000);   /* net schedule list every 60s — the we
                                           badge/highlight itself re-derives every second
                                           from tickSecond(), this just catches edits made
                                           from another browser/tab */
+
+/* Background-tab timer throttling (Chrome et al. clamp setInterval to a
+   floor of ~1/sec once hidden, then to ~1/min after several minutes hidden)
+   means refreshBoard()'s normal 2s cadence can silently stretch out while
+   this tab isn't the active one. Two things visibly rot during that stretch:
+   the keyed-activity timeline (renderKeyedTimeline) shows long gaps as
+   empty/transparent bars since recordKeyedHistory never got a sample to
+   record, and the favicon dot (updateFaviconState) sits frozen on whatever
+   state the last throttled poll saw. Neither is fixable while the tab stays
+   backgrounded — that throttling is deliberate browser power-saving, not a
+   bug here — but there's no reason to also wait out however long the
+   browser's own backlogged timer schedule takes to fire again once the tab
+   *is* back in view: refreshing immediately on regained visibility snaps
+   both back to truth the instant anyone actually looks (issue #125). */
+document.addEventListener('visibilitychange', function() {
+  if (document.visibilityState === 'visible') refreshBoard();
+});
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Fixes #125: the per-connection keyed-activity timeline bar and the browser-tab favicon dot go stale while the kiosk tab is hidden/occluded, only catching up whenever the browser's own throttled poll timer next happens to fire.
- Root cause: browsers clamp `setInterval` once a tab is hidden or occluded by another window (and clamp harder after several minutes), so `refreshBoard()`'s normal 2s cadence can silently stretch out to tens of seconds or more. During that stretch, `recordKeyedHistory()` gets no samples (rendering the timeline's `.nr-tl-bar` as empty/transparent — effectively invisible) and `updateFaviconState()` freezes on the last state it saw before backgrounding.
- Fix: a `visibilitychange` listener now calls `refreshBoard()` immediately when the tab becomes visible again, so both the timeline and the favicon dot snap back to the true current state the instant anyone looks, instead of waiting out however long the browser's own backlogged timer schedule takes to fire next.
- This can't fix staleness *while* the tab stays backgrounded — that throttling is deliberate browser power-saving, not a bug in HenWen — but it removes the extra, unnecessary delay on the way back.

## Test plan
- [x] `node -c` syntax check on the extracted `<script>` block
- [ ] Manual: open the kiosk board, key up a connected node, switch to another tab/app for >30s while it's keyed, switch back — timeline bar and tab favicon dot should reflect current state immediately on return

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XC8BhccFrR9jrrG9x5C45U