### PR TITLE
Add idle-timeout control for kiosk-untracked connections (issue #121)

### DIFF
--- a/app.py
+++ b/app.py
@@ -7683,7 +7683,21 @@ def api_status_squash_idle():
 def api_status_restore_idle():
     """Undo /api/status/squash-idle — re-enable the idle-timeout auto-disconnect
     for a connection that was exempted from it. Resets the idle clock to now,
-    since time spent exempted was never counted as elapsed idle time."""
+    since time spent exempted was never counted as elapsed idle time.
+
+    Also doubles as "start tracking" for a connection _kiosk_temp_conns never
+    had an entry for at all — an external node that dialed into this one, or
+    a link made directly via the Asterisk CLI before HenWen was tracking it.
+    Those show up on the Status Board with no idle-timeout badge/control of
+    any kind, not even a squashed one, since none of the permanent/no_timeout/
+    tracked-elapsed branches match a row that's simply absent (issue #121).
+    Reusing this endpoint rather than adding a separate one: the end state a
+    user wants by clicking the clock icon is identical either way — the idle
+    clock starts counting from now. `monitor` is optional and only cosmetic
+    (round-tripped to kiosk_temp_conns/the DB for display elsewhere); a fresh
+    entry defaults it False, same as squash-idle's own fresh-entry branch,
+    since the caller has no way to know the link's actual R/T mode from here.
+    """
     if session.get('role') not in ('admin', 'superuser', 'owner'):
         return jsonify({"error": "Admin access required"}), 403
     data        = request.json or {}
@@ -7695,14 +7709,18 @@ def api_status_restore_idle():
         return jsonify({"error": "Invalid remote_node"}), 400
     key = (local_node, remote_node)
     with _kiosk_temp_lock:
-        if key not in _kiosk_temp_conns or _kiosk_temp_conns[key].get('permanent'):
-            return jsonify({"error": "Not a tracked temporary connection"}), 404
-        _kiosk_temp_conns[key]['no_timeout']  = False
-        _kiosk_temp_conns[key]['last_active'] = time.time()
+        if key in _kiosk_temp_conns and _kiosk_temp_conns[key].get('permanent'):
+            return jsonify({"error": "Not a trackable connection"}), 404
+        if key not in _kiosk_temp_conns:
+            _kiosk_temp_conns[key] = {'permanent': False, 'monitor': False,
+                                       'no_timeout': False, 'last_active': time.time()}
+        else:
+            _kiosk_temp_conns[key]['no_timeout']  = False
+            _kiosk_temp_conns[key]['last_active'] = time.time()
         info = dict(_kiosk_temp_conns[key])
     _db_temp_conn_save(local_node, remote_node, info.get('monitor', False),
                        False, info['last_active'])
-    log("INFO", f"[API] /api/status/restore-idle {local_node} -> {remote_node}: idle timeout re-enabled")
+    log("INFO", f"[API] /api/status/restore-idle {local_node} -> {remote_node}: idle timeout enabled")
     return jsonify({"ok": True})
 
 

--- a/templates/status.html
+++ b/templates/status.html
@@ -4269,6 +4269,25 @@ async function refreshBoard() {
           idleBadge = '<span class="idle-badge off">' + clockBtn + '</span>';
         } else if (c.permanent === true) {
           idleBadge = '<span class="idle-badge">Permanent</span>';
+        } else if (c.permanent == null && isConn) {
+          /* Untracked connection: established outside the kiosk's own connect
+             flow (an external node dialing into this one, or one made
+             directly via the Asterisk CLI before HenWen started tracking it)
+             — _kiosk_temp_conns never got an entry for it, so none of the
+             idle-elapsed/no-timeout/permanent branches above match and there
+             would otherwise be no idle-timeout control here at all (issue
+             #121). Same clock icon/button as the "No Timeout" case above,
+             but sbRestoreIdle's endpoint now starts tracking a previously-
+             untracked connection instead of 404ing, so clicking it here
+             begins enforcing the idle timeout from now rather than
+             "restoring" a state that never existed. */
+          var isAdmin3 = window._kioskRole === 'admin' || window._kioskRole === 'superuser' || window._kioskRole === 'owner';
+          var trackBtn = isAdmin3
+            ? '<button class="idle-restore-btn" onclick="sbRestoreIdle(\'' +
+                esc(c.local_node) + '\',\'' + esc(c.node) + '\',this)" ' +
+                'title="Not tracked for idle timeout (connected outside the kiosk) — click to start enforcing the idle timeout on this connection"><svg class="icon"><use href="#icon-clock"></use></svg></button>'
+            : '<span title="Not tracked for idle timeout — connected outside the kiosk"><svg class="icon"><use href="#icon-clock"></use></svg></span>';
+          idleBadge = '<span class="idle-badge off">' + trackBtn + '</span>';
         }
         var badges = modeBadge + idleBadge;
         var dotClass = !isConn ? ' connecting' : (c.keyed ? ' keyed' : ' connected');


### PR DESCRIPTION
## Summary
- Fixes #121: when an external node connects into the local HenWen node (or a link is made directly via the Asterisk CLI before HenWen starts tracking it), the Status Board shows no idle-timeout control at all for that connection — not even the "No Timeout" clock icon — so there's no way to opt it into idle-timeout auto-disconnect.
- Root cause: `_kiosk_temp_conns` (the in-process dict backing every idle-timeout badge/button) is only ever populated by the kiosk's own connect flow (`sbConnect`) or `/api/status/squash-idle`. A connection nobody made through the kiosk has no entry, so its `permanent`/`no_timeout` fields both come back `None` ("not tracked" per the existing board-route comment) — which doesn't match any of the frontend's idle-badge branches, so nothing renders at all.
- Fix:
  - `templates/status.html`: added a branch for the untracked case (`c.permanent == null`) that renders the same clock-icon button as the existing "No Timeout" state, admin+ gated the same way, reusing the existing `sbRestoreIdle()` call.
  - `app.py`: `/api/status/restore-idle` now initializes a fresh `_kiosk_temp_conns` entry (instead of 404ing with "Not a tracked temporary connection") when the connection isn't tracked at all, so clicking the clock button begins enforcing the idle timeout on it from that point forward — the same end state as "re-enabling" a previously-squashed connection.

## Test plan
- [x] `python3 -m py_compile app.py`
- [x] `node -c` syntax check on the extracted `<script>` block
- [x] `./venv/bin/pytest` — 640 passed
- [ ] Manual: have an external node connect into the local node, confirm the clock button now appears and clicking it starts the idle countdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XC8BhccFrR9jrrG9x5C45U