### PR TITLE
Add Rx%/LCnt keyed duty-cycle columns to Favorites (issue #113)

### DIFF
--- a/app.py
+++ b/app.py
@@ -2930,6 +2930,22 @@ _favstats_cache    = {}   # {node: {"keyed": bool, "connected_count": int, "erro
 _favstats_cache_ts = {}   # {node: float unix timestamp}
 _favstats_lock     = threading.Lock()
 
+# Rolling keyed-sample history behind the Favorites "Rx%"/"LCnt" columns
+# (issue #113, modeled on AllScan's own Rx%/LCnt columns for its
+# connected-node list). Each successful favstats poll appends one
+# (ts, keyed) sample per node — a failed cycle (network error, 429) is
+# skipped entirely rather than recorded as "not keyed", since a
+# stats.allstarlink.org outage must not silently drag every favorite's
+# duty cycle toward 0%. Rx% is samples-keyed / samples-total over the
+# window; LCnt is the count of False->True transitions across that same
+# sample sequence — the polled-snapshot analog of _link_stats' "keyups",
+# which counts real transitions from the continuous 1s AMI poll instead.
+# Bounded by wall-clock age, not sample count, since FAVORITES_POLL_INTERVAL
+# can change at runtime via env var and a count-based cap would silently
+# shrink/grow the effective time window along with it.
+_favstats_history       = {}   # {node: deque[(ts, keyed_bool)]}
+FAVSTATS_PCT_WINDOW_SEC = float(os.environ.get("FAVSTATS_PCT_WINDOW_SEC", "21600"))  # 6h
+
 
 def _fetch_node_stats(node: str) -> dict:
     """
@@ -2973,6 +2989,9 @@ def _favstats_poll_loop():
         try:
             db    = get_db()
             nodes = [r["node"] for r in db.execute("SELECT DISTINCT node FROM favorites").fetchall()]
+            with _favstats_lock:
+                for gone in set(_favstats_history) - set(nodes):
+                    del _favstats_history[gone]
             for node in nodes:
                 try:
                     result = _fetch_node_stats(node)
@@ -2983,9 +3002,16 @@ def _favstats_poll_loop():
                         any_429 = True
                     log("WARN", f"[FAVSTATS-POLL] {node}: {e}")
                     result = {"keyed": False, "connected_count": 0, "error": err_str}
+                now = time.time()
                 with _favstats_lock:
                     _favstats_cache[node]    = result
-                    _favstats_cache_ts[node] = time.time()
+                    _favstats_cache_ts[node] = now
+                    if result["error"] is None:
+                        hist   = _favstats_history.setdefault(node, deque())
+                        cutoff = now - FAVSTATS_PCT_WINDOW_SEC
+                        hist.append((now, result["keyed"]))
+                        while hist and hist[0][0] < cutoff:
+                            hist.popleft()
                 # Pacing gap between nodes within a cycle, on top of the
                 # interval between whole cycles. Confirmed live that a tight
                 # burst (originally 0.3s apart) across just 6 nodes was
@@ -4525,10 +4551,21 @@ def get_cached_favstats(node: str) -> dict:
     with _favstats_lock:
         entry = _favstats_cache.get(node)
         ts    = _favstats_cache_ts.get(node, 0)
+        hist  = list(_favstats_history.get(node, ()))
     age = time.time() - ts
+    # keyed_pct/keyups are None until at least one clean (non-error) sample
+    # has landed, rather than 0 — 0% and "no data yet" must render
+    # differently in the UI (see fav-pct-<node> in henwen-manager.html).
+    keyed_pct = None
+    keyups    = None
+    if hist:
+        keyed_pct = round(100 * sum(1 for _, k in hist if k) / len(hist))
+        keyups    = sum(1 for i in range(1, len(hist)) if hist[i][1] and not hist[i - 1][1])
     if entry is None:
-        return {"node": node, "keyed": False, "connected_count": 0, "stale": True, "age": None}
-    return {**entry, "node": node, "stale": age > FAVORITES_POLL_INTERVAL * 3, "age": round(age, 2)}
+        return {"node": node, "keyed": False, "connected_count": 0, "stale": True, "age": None,
+                "keyed_pct": keyed_pct, "keyups": keyups}
+    return {**entry, "node": node, "stale": age > FAVORITES_POLL_INTERVAL * 3, "age": round(age, 2),
+            "keyed_pct": keyed_pct, "keyups": keyups}
 
 
 def ami_send_command(subcmd_fn) -> dict:

--- a/templates/henwen-manager.html
+++ b/templates/henwen-manager.html
@@ -920,9 +920,11 @@ pre.codeblock { background: var(--bg3); padding: 12px; border-radius: 4px; font-
         </div>
       </div>
       <table class="tbl">
-        <thead><tr><th></th><th>Node</th><th>Label</th><th>Callsign</th><th>Location</th><th>Keyed</th><th>Connected</th><th>Actions</th></tr></thead>
+        <thead><tr><th></th><th>Node</th><th>Label</th><th>Callsign</th><th>Location</th><th>Keyed</th><th>Connected</th>
+          <th title="Percent of polled samples (last 6h) this node was keyed, and how many times it keyed up in that window — see FAVSTATS_PCT_WINDOW_SEC">Rx% / LCnt</th>
+          <th>Actions</th></tr></thead>
         <tbody id="fav-tbody">
-          <tr><td colspan="8" class="muted" style="padding:14px">Loading...</td></tr>
+          <tr><td colspan="9" class="muted" style="padding:14px">Loading...</td></tr>
         </tbody>
       </table>
     </div>
@@ -5195,10 +5197,10 @@ function _mgrFavoritesForDisplay() {
 
 async function loadFavorites() {
   var tbody = document.getElementById('fav-tbody');
-  tbody.innerHTML = '<tr><td colspan="8" class="muted" style="padding:14px">Loading...</td></tr>';
+  tbody.innerHTML = '<tr><td colspan="9" class="muted" style="padding:14px">Loading...</td></tr>';
   var r = await api('/api/favorites');
   if (!r.ok) {
-    tbody.innerHTML = '<tr><td colspan="8" class="muted" style="padding:14px">' + esc(r.data.error || 'Failed') + '</td></tr>';
+    tbody.innerHTML = '<tr><td colspan="9" class="muted" style="padding:14px">' + esc(r.data.error || 'Failed') + '</td></tr>';
     return;
   }
   _mgrFavorites = r.data.favorites || [];
@@ -5212,7 +5214,7 @@ function renderMgrFavorites() {
   var tbody = document.getElementById('fav-tbody');
   if (!tbody) return;
   if (!_mgrFavorites.length) {
-    tbody.innerHTML = '<tr><td colspan="8" class="muted" style="padding:14px">No favorites yet. Use Add Node above.</td></tr>';
+    tbody.innerHTML = '<tr><td colspan="9" class="muted" style="padding:14px">No favorites yet. Use Add Node above.</td></tr>';
     return;
   }
   var isCustomSort = _mgrFavSort.field === 'custom';
@@ -5230,6 +5232,7 @@ function renderMgrFavorites() {
       + '<td>' + esc(f.location || '') + '</td>'
       + '<td id="fav-keyed-' + esc(f.node) + '"><span class="muted">...</span></td>'
       + '<td id="fav-conn-' + esc(f.node) + '" class="mono"><span class="muted">...</span></td>'
+      + '<td id="fav-pct-' + esc(f.node) + '" class="mono"><span class="muted">...</span></td>'
       + '<td><div class="btn-row">'
       + '<button class="btn btn-sm btn-primary" onclick="favConnect(\'' + esc(f.node) + '\')">Connect</button>'
       + '<button class="btn btn-sm" onclick="favFill(\'' + esc(f.node) + '\')">Fill</button>'
@@ -5303,6 +5306,7 @@ async function updateFavoritesStatus() {
     var s = favs[node];
     var keyedCell = document.getElementById('fav-keyed-' + node);
     var connCell  = document.getElementById('fav-conn-' + node);
+    var pctCell   = document.getElementById('fav-pct-' + node);
     if (keyedCell) {
       if (s.error) {
         keyedCell.innerHTML = '<span class="muted" title="' + esc(s.error) + '">N/A</span>';
@@ -5314,6 +5318,14 @@ async function updateFavoritesStatus() {
     }
     if (connCell) {
       connCell.textContent = s.error ? '—' : s.connected_count;
+    }
+    if (pctCell) {
+      // keyed_pct/keyups are null until at least one clean (non-error) poll
+      // sample has landed for this node — see get_cached_favstats() in
+      // app.py — so render a muted placeholder rather than "0%" until then.
+      pctCell.innerHTML = (s.keyed_pct === null || s.keyed_pct === undefined)
+        ? '<span class="muted">—</span>'
+        : (s.keyed_pct + '% / ' + s.keyups);
     }
   });
 }

--- a/templates/status.html
+++ b/templates/status.html
@@ -938,8 +938,10 @@ html, body { height: 100%; background: var(--bg); color: var(--text);
 .fav-num  { font-size: 0.9rem; font-weight: 700; font-family: var(--mono); color: var(--accent); text-decoration: none; }
 .fav-call { font-size: 0.75rem; font-weight: 600; color: var(--text); text-decoration: none; }
 .fav-call:hover { text-decoration: underline; }
-.fav-loc  { font-size: 0.67rem; color: var(--text2); overflow: hidden;
-  text-overflow: ellipsis; white-space: nowrap; }
+.fav-loc  { font-size: 0.67rem; color: var(--text2); display: flex; align-items: baseline;
+  gap: 6px; min-width: 0; }
+.fav-loc-text { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+.fav-pct  { flex-shrink: 0; color: var(--text2); opacity: 0.85; }
 /* gap bumped 3px -> 6px alongside .sb-btn's taller padding below (issue #102):
    Lighthouse's target-size audit checks clickable space between neighbors as
    well as each target's own size, and the stacked Connect/Monitor pair here
@@ -5391,6 +5393,13 @@ async function checkKioskSession() {
 
 /* ── Favorites sidebar ── */
 var _favorites = [];
+/* {node: {keyed_pct, keyups, ...}} from /api/favorites/status — the same
+   rolling-sample Rx%/LCnt duty-cycle cache the Manager Favorites table
+   reads (see updateFavoritesStatus() in henwen-manager.html and
+   get_cached_favstats() in app.py, issue #113). Populated only once
+   logged in (the route 401s to an empty object otherwise), same gate as
+   /api/favorites itself. */
+var _favStatus = {};
 
 /* Sort preference is view-only and per-browser (localStorage), separate from
    the server-side custom order: "custom" displays favorites.sort_order as-is
@@ -5470,6 +5479,21 @@ async function loadFavorites() {
     if (!r.ok) return;
     var d = await r.json();
     _favorites = d.favorites || [];
+    renderFavorites();
+  } catch(e) {}
+}
+
+/* Rx%/LCnt cells update in place on their own timer, same "cheap re-read of
+   an already-throttled server-side cache" reasoning as
+   updateFavoritesStatus() in henwen-manager.html — the external stats API
+   poll itself stays on its own multi-minute cadence regardless of how often
+   this is called. */
+async function loadFavStatus() {
+  try {
+    var r = await apiFetch('/api/favorites/status', {cache: 'no-store'});
+    if (!r.ok) return;
+    var d = await r.json();
+    _favStatus = d.favorites || {};
     renderFavorites();
   } catch(e) {}
 }
@@ -5562,6 +5586,11 @@ function renderFavorites() {
        instead of being stuck on a stored placeholder. */
     var name    = f.label || f.callsign || ('Node ' + f.node);
     var loc     = f.location || '';
+    var st      = _favStatus[f.node];
+    var pctText = (st && st.keyed_pct !== null && st.keyed_pct !== undefined)
+      ? ('Rx ' + st.keyed_pct + '%') : '';
+    var pctTitle = pctText ? (' title="Percent of polled samples keyed, last 6h (' +
+      st.keyups + ' keyups)"') : '';
     var handle  = isCustomSort ? '<span class="fav-drag-handle" title="Drag to reorder"><svg class="icon"><use href="#icon-grip-vertical"></use></svg></span>' : '';
     var dragAttrs = isCustomSort ?
       ' draggable="true" ondragstart="favRowDragStart(event,\'' + esc(f.node) + '\')"' +
@@ -5602,7 +5631,10 @@ function renderFavorites() {
           (f.callsign ? callsignLink(f.callsign, 'fav-call', name) : (name ? '<span class="fav-call">' + esc(name) + '</span>' : '')) +
           '<button class="fav-del-btn" onclick="removeFavorite(\'' + esc(f.node) + '\')" title="Remove from Favorites">✕</button>' +
         '</div>' +
-        (loc ? '<div class="fav-loc">' + esc(loc) + '</div>' : '') +
+        ((loc || pctText) ? '<div class="fav-loc">' +
+          (loc ? '<span class="fav-loc-text">' + esc(loc) + '</span>' : '') +
+          (pctText ? '<span class="fav-pct"' + pctTitle + '>' + esc(pctText) + '</span>' : '') +
+          '</div>' : '') +
       '</div>' +
       '<div class="fav-actions">' + actions + '</div>' +
     '</div>';
@@ -8361,6 +8393,7 @@ refreshActivity();
 loadMeshtasticMessages();
 initFavSort();
 loadFavorites();
+loadFavStatus();
 checkKioskSession();
 fetchNets();
 
@@ -8377,6 +8410,10 @@ setInterval(refreshWeather,  600000);  /* weather every 10min */
 setInterval(refreshNwsAlerts, 60000);  /* NWS alert ticker every 60s — well under the
                                           poller's own 120s cadence, just catches up
                                           promptly after a config change */
+setInterval(loadFavStatus,  10000);    /* Favorites Rx%/LCnt cells every 10s — reads
+                                          only the already-throttled server-side favstats
+                                          cache (see FAVORITES_POLL_INTERVAL in app.py),
+                                          so this cadence adds no external load */
 setInterval(fetchNets,       60000);   /* net schedule list every 60s — the weather-bar
                                           badge/highlight itself re-derives every second
                                           from tickSecond(), this just catches edits made

--- a/tests/test_favstats_pct.py
+++ b/tests/test_favstats_pct.py
@@ -1,0 +1,108 @@
+"""Tests for the Favorites "Rx%"/"LCnt" duty-cycle columns (issue #113,
+modeled on AllScan's own Rx%/LCnt columns for its connected-node list).
+
+get_cached_favstats() derives keyed_pct/keyups from _favstats_history, a
+rolling (ts, keyed) sample deque appended to by the favstats poller on every
+clean (non-error) cycle -- see _favstats_poll_loop's own comments in app.py.
+These tests drive that derivation directly by seeding _favstats_history,
+without needing a live poller thread or network access.
+"""
+import time
+
+import pytest
+
+import app
+
+
+@pytest.fixture(autouse=True)
+def _clean_favstats_state(monkeypatch):
+    monkeypatch.setattr(app, "_favstats_cache", {})
+    monkeypatch.setattr(app, "_favstats_cache_ts", {})
+    monkeypatch.setattr(app, "_favstats_history", {})
+
+
+def _seed(node, keyed_sequence, start_ts=1000.0, step=180.0):
+    hist = [(start_ts + i * step, k) for i, k in enumerate(keyed_sequence)]
+    app._favstats_history[node] = app.deque(hist)
+    app._favstats_cache[node]    = {"keyed": keyed_sequence[-1], "connected_count": 0, "error": None}
+    app._favstats_cache_ts[node] = time.time()
+
+
+class TestKeyedPct:
+    def test_no_samples_yet_is_none_not_zero(self):
+        # A favorite with no clean poll cycle yet must read as "no data",
+        # not as a false 0% duty cycle.
+        data = app.get_cached_favstats("54576")
+        assert data["keyed_pct"] is None
+        assert data["keyups"] is None
+
+    def test_all_keyed_samples_is_100_pct(self):
+        _seed("27339", [True, True, True, True])
+        data = app.get_cached_favstats("27339")
+        assert data["keyed_pct"] == 100
+
+    def test_all_unkeyed_samples_is_0_pct(self):
+        _seed("47243", [False, False, False])
+        data = app.get_cached_favstats("47243")
+        assert data["keyed_pct"] == 0
+
+    def test_mixed_samples_rounds_to_nearest_percent(self):
+        # 3 of 8 keyed = 37.5% -> rounds to 38, matching AllScan's own
+        # rounding in the referenced screenshot (issue #113).
+        _seed("64549", [True, False, False, True, False, False, False, True])
+        data = app.get_cached_favstats("64549")
+        assert data["keyed_pct"] == 38
+
+    def test_error_cycles_are_never_recorded_as_unkeyed_samples(self, monkeypatch):
+        # An API outage (429 / DNS failure / etc.) must not silently drag
+        # every favorite's duty cycle toward 0% -- _favstats_poll_loop skips
+        # appending a history sample entirely on an error result, so a run
+        # of nothing but errors leaves keyed_pct at None, not 0.
+        app._favstats_cache["666380"]    = {"keyed": False, "connected_count": 0, "error": "HTTP 429"}
+        app._favstats_cache_ts["666380"] = time.time()
+        data = app.get_cached_favstats("666380")
+        assert data["keyed_pct"] is None
+        assert data["keyups"] is None
+
+
+class TestKeyups:
+    def test_counts_false_to_true_transitions_only(self):
+        # Two keyups: index 0 (True with no prior sample doesn't count as a
+        # transition), index 3 (False->True), index 6 (False->True). A
+        # True->True run (indices 0-1) or True immediately followed by
+        # another True is not a second keyup.
+        _seed("472440", [True, True, False, True, True, False, True])
+        data = app.get_cached_favstats("472440")
+        assert data["keyups"] == 2
+
+    def test_never_keyed_has_zero_keyups(self):
+        _seed("27404", [False, False, False, False])
+        data = app.get_cached_favstats("27404")
+        assert data["keyups"] == 0
+
+    def test_single_sample_has_zero_keyups(self):
+        # No prior sample to transition from, regardless of its own state.
+        _seed("27664", [True])
+        data = app.get_cached_favstats("27664")
+        assert data["keyups"] == 0
+
+
+class TestHistoryPruning:
+    def test_poll_loop_drops_samples_older_than_the_window(self, monkeypatch):
+        # Mirrors the pruning _favstats_poll_loop does inline on every
+        # append (see its own comment) -- a sample older than
+        # FAVSTATS_PCT_WINDOW_SEC must not keep dragging keyed_pct once it
+        # ages out, the same way _link_stats/_keyed_history are bounded.
+        monkeypatch.setattr(app, "FAVSTATS_PCT_WINDOW_SEC", 600.0)
+        now = time.time()
+        hist = app.deque([
+            (now - 10000, True),   # long expired -- would flip this to 100% if kept
+            (now - 100, False),
+            (now - 50, False),
+        ])
+        app._favstats_history["55553"] = hist
+        cutoff = now - app.FAVSTATS_PCT_WINDOW_SEC
+        while hist and hist[0][0] < cutoff:
+            hist.popleft()
+        data = app.get_cached_favstats("55553")
+        assert data["keyed_pct"] == 0


### PR DESCRIPTION
## Summary
- Adds AllScan-style Rx%/LCnt columns to the Favorites feature, closing #113.
- The favstats poller (`_favstats_poll_loop`) now appends a `(ts, keyed)` sample per favorite node on every clean (non-error) poll cycle into a rolling 6h history (`_favstats_history`, window via `FAVSTATS_PCT_WINDOW_SEC`). Failed cycles (429/network error) are skipped, not recorded as "unkeyed", so an API outage can't drag every favorite's duty cycle toward 0%.
- `get_cached_favstats()` derives `keyed_pct` (percent of samples keyed) and `keyups` (count of False→True transitions — the LCnt equivalent) from that history and returns them via the existing `/api/favorites/status` route.
- Manager > Favorites table gets a new "Rx% / LCnt" column, filled in by the existing `updateFavoritesStatus()` poll.
- Kiosk sidebar's Favorites panel gets a small "Rx NN%" badge next to each favorite's location, via a new `loadFavStatus()` poll (10s, reads only the already-throttled server-side cache).

## Notes
- Not deployed to the live box for manual verification yet — the box's `/opt/HenWen` checkout currently has PR #136 (issue #132) deployed and awaiting a merge decision, so I didn't want to swap that checkout out from under it. Ran the full test suite instead (649 passed) plus new unit tests for the pct/keyups derivation logic.
- No new external API calls — this rides entirely on the existing favstats poller's already-throttled requests to stats.allstarlink.org.

## Test plan
- [x] `./venv/bin/pytest` — 649 passed, including new `tests/test_favstats_pct.py`
- [ ] Manual verification against the live board once it's safe to deploy this branch (Rx%/LCnt columns populate correctly in Manager > Favorites and the kiosk Favorites sidebar for a favorite with real activity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RyXFaGsPQ7TCDWDkDXokV