### PR TITLE
Confirm before bridging when connecting a node with another already linked (issue #140)

### DIFF
--- a/templates/status.html
+++ b/templates/status.html
@@ -5043,8 +5043,31 @@ function sbToast(msg, ok) {
   _sbToastTimer = setTimeout(function() { t.className = ''; }, 3500);
 }
 
-async function sbConnect(localNode, remoteNode, btn, permanent, monitor) {
+async function sbConnect(localNode, remoteNode, btn, permanent, monitor, skipConfirm) {
   var label = monitor ? 'Monitor' : 'Connect';
+  /* issue #140: warn before bridging two networks together. Every Connect/
+     Monitor button on the board (node card, Node Search, Favorites, map
+     popups, net-schedule Join) funnels through this one function, so this
+     is the single place to catch it rather than repeating the check at
+     each caller. Only fires when localNode already has some *other* node
+     connected -- connecting the first node, or re-clicking Connect on a
+     node that's already linked, is not a bridging risk. skipConfirm is set
+     on the openKioskLogin() retry below so a login round-trip doesn't ask
+     the same question twice. */
+  if (!skipConfirm) {
+    var already = [];
+    (window._lastBoardNodes || []).forEach(function(n) {
+      if (String(n.node) !== String(localNode)) return;
+      (n.connected || []).forEach(function(c) {
+        if (String(c.node) !== String(remoteNode)) already.push(c.node);
+      });
+    });
+    if (already.length && !confirm(
+        'Node ' + localNode + ' is already connected to ' + already.join(', ') + '. ' +
+        (monitor ? 'Monitoring' : 'Connecting') + ' ' + remoteNode + ' too will bridge audio between all of them. Continue?')) {
+      return;
+    }
+  }
   /* A map pin's popup is the one caller of this function whose button lives
      inside content updateMap() refuses to touch while any popup is open
      (see the popupopen/popupclose handlers in initMap()) -- that guard
@@ -5077,7 +5100,7 @@ async function sbConnect(localNode, remoteNode, btn, permanent, monitor) {
       setTimeout(refreshBoard, 1500);
     } else if (r.status === 401) {
       if (btn) { btn.disabled = false; btn.textContent = label; }
-      openKioskLogin(sbConnect, [localNode, remoteNode, null, permanent, monitor]);
+      openKioskLogin(sbConnect, [localNode, remoteNode, null, permanent, monitor, true]);
     } else {
       sbToast(label + ' failed: ' + (d.error || r.status), false);
       if (btn) { btn.disabled = false; btn.textContent = label; }


### PR DESCRIPTION
## Summary
- Closes #140: warn the user before connecting/monitoring a node when the local node already has another node connected, since that bridges audio between them and can cause interference.
- The check lives once in `sbConnect()`, the single function every Connect/Monitor button on the board funnels through (node card, Node Search/EchoLink search modal, Favorites sidebar, map popups, net-schedule "Join"), so every path gets the same warning without repeating the check per-caller.
- Uses a native `confirm()` dialog, matching the only other confirmation pattern already in this file (delete recording / delete net reminder) rather than introducing a new custom modal for one dialog.
- Applies regardless of role — the pre-existing Favorites-only hard block for plain `user` accounts (added in a6e7390) is untouched and still short-circuits before ever reaching `sbConnect()` for that specific path/role, so it isn't double-prompted.
- The automatic retry after an inline login prompt skips re-asking (`skipConfirm=true`), since the user already answered the question before the 401 was seen.

## Test plan
- [x] `node --check` on the extracted inline script (syntax only)
- [x] Deployed to `/opt/HenWen`, restarted `HenWen`, confirmed the new code is served
- [ ] User to exercise live: with one node already connected to a local node, try Connect/Monitor from the node card, Node Search, Favorites (admin+), a map popup, and a net-schedule Join — confirm the dialog appears in each, and that connecting a *first* node (nothing else connected yet) shows no dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RyXFaGsPQ7TCDWDkDXokV