### PR TITLE
Add Owner-triggered kiosk banner (issue #138)

### DIFF
--- a/app.py
+++ b/app.py
@@ -990,6 +990,23 @@ def get_db():
         locked_at  TEXT NOT NULL DEFAULT (datetime('now'))
     )""")
     conn.commit()
+    # Singleton, Owner-triggered banner shown board-wide on the public Status
+    # Board (issue #138) -- same "system-wide, visible to every anonymous
+    # kiosk viewer" shape as node_lockouts above, so it gets the same
+    # owner-only gate. expires_at is a unix timestamp (REAL), matching
+    # invites.expires_at's convention, rather than a TEXT datetime() string
+    # like locked_at above -- it's compared against time.time() on every
+    # board refresh (see _get_active_kiosk_banner()), and a float compare is
+    # simpler and cheaper than parsing a stored datetime string each time.
+    # message='' or expires_at IS NULL both mean "no active banner".
+    conn.execute("""CREATE TABLE IF NOT EXISTS kiosk_banner (
+        id          INTEGER PRIMARY KEY CHECK (id = 1),
+        message     TEXT NOT NULL DEFAULT '',
+        expires_at  REAL,
+        created_by  TEXT NOT NULL DEFAULT '',
+        created_at  REAL
+    )""")
+    conn.commit()
     # One row per in-browser recording session (recording.py). No equivalent
     # table exists for the stream relay — that's a continuous service, not a
     # set of discrete sessions; see stream_relay_config above.
@@ -1218,6 +1235,27 @@ def get_locked_nodes():
 
 def is_any_node_locked():
     return get_db().execute("SELECT 1 FROM node_lockouts LIMIT 1").fetchone() is not None
+
+
+# ---------------------------------------------------------------------------
+# Kiosk banner (Owner-only, issue #138)
+# ---------------------------------------------------------------------------
+def _get_active_kiosk_banner():
+    """{'message':..., 'expires_at':..., 'created_by':...} if a banner is
+    currently live (message non-empty and not yet past its expires_at), else
+    None. A past-expiry row is left in place rather than deleted here --
+    _get_active_kiosk_banner() is called on every /api/status/board request
+    (up to once per kiosk viewer per 2s), so this stays a read-only check;
+    the row is only ever overwritten by the next api_kiosk_banner_set() call
+    or wiped by api_kiosk_banner_clear()."""
+    row = get_db().execute(
+        "SELECT message, expires_at, created_by FROM kiosk_banner WHERE id=1").fetchone()
+    if not row or not row["message"] or not row["expires_at"]:
+        return None
+    if time.time() >= row["expires_at"]:
+        return None
+    return {"message": row["message"], "expires_at": row["expires_at"],
+            "created_by": row["created_by"]}
 
 
 # ---------------------------------------------------------------------------
@@ -7440,6 +7478,7 @@ def api_status_board():
         "connector_warning": _connector_upcoming_disconnect_all(),
         "active_announcements": active_announcements,
         "scheduled_connectors": scheduled_connectors,
+        "banner":            _get_active_kiosk_banner(),
     })
     resp.headers["Cache-Control"] = "no-store"
     return resp
@@ -7474,6 +7513,62 @@ def api_node_lockout(node):
     db.commit()
     log("INFO", f"[LOCKOUT] Node {node} {'locked' if locked else 'unlocked'} by {session.get('username', '')}")
     return jsonify({"ok": True, "node": node, "locked": locked})
+
+
+_KIOSK_BANNER_MAX_MESSAGE_LEN = 300
+_KIOSK_BANNER_MAX_DURATION_MIN = 10080  # 7 days
+
+
+@app.route("/api/kiosk/banner", methods=["POST"])
+def api_kiosk_banner_set():
+    """Owner-only. Sets (or replaces) the board-wide kiosk banner for a
+    fixed duration -- see issue #138. Every kiosk viewer, logged in or not,
+    sees this, so it gets the same owner-only gate as node lockout above."""
+    if session.get('role') != 'owner':
+        return jsonify({"error": "Only the owner can set the kiosk banner"}), 403
+    data    = request.json or {}
+    message = str(data.get("message", "")).strip()
+    if not message:
+        return jsonify({"error": "Banner message is required"}), 400
+    if len(message) > _KIOSK_BANNER_MAX_MESSAGE_LEN:
+        return jsonify({"error": f"Banner message must be {_KIOSK_BANNER_MAX_MESSAGE_LEN} characters or fewer"}), 400
+    try:
+        duration_min = int(data.get("duration_min", 0))
+    except (TypeError, ValueError):
+        return jsonify({"error": "duration_min must be a number"}), 400
+    if not (1 <= duration_min <= _KIOSK_BANNER_MAX_DURATION_MIN):
+        return jsonify({"error": f"duration_min must be between 1 and {_KIOSK_BANNER_MAX_DURATION_MIN}"}), 400
+
+    now        = time.time()
+    expires_at = now + duration_min * 60
+    username   = session.get('username', '')
+    db = get_db()
+    db.execute(
+        """INSERT INTO kiosk_banner (id, message, expires_at, created_by, created_at)
+           VALUES (1, ?, ?, ?, ?)
+           ON CONFLICT(id) DO UPDATE SET message=excluded.message,
+               expires_at=excluded.expires_at, created_by=excluded.created_by,
+               created_at=excluded.created_at""",
+        (message, expires_at, username, now)
+    )
+    db.commit()
+    log("INFO", f"[BANNER] Kiosk banner set by {username} for {duration_min}min: {message!r}")
+    return jsonify({"ok": True, "banner": {"message": message, "expires_at": expires_at, "created_by": username}})
+
+
+@app.route("/api/kiosk/banner", methods=["DELETE"])
+def api_kiosk_banner_clear():
+    """Owner-only. Clears an active kiosk banner early. Row is blanked, not
+    deleted -- kiosk_banner is a singleton table (id=1 always exists once
+    api_kiosk_banner_set() has run once; a no-op UPDATE is harmless if it
+    hasn't)."""
+    if session.get('role') != 'owner':
+        return jsonify({"error": "Only the owner can clear the kiosk banner"}), 403
+    db = get_db()
+    db.execute("UPDATE kiosk_banner SET message='', expires_at=NULL WHERE id=1")
+    db.commit()
+    log("INFO", f"[BANNER] Kiosk banner cleared by {session.get('username', '')}")
+    return jsonify({"ok": True})
 
 
 @app.route("/api/status/active_users")

--- a/templates/henwen-manager.html
+++ b/templates/henwen-manager.html
@@ -851,6 +851,46 @@ pre.codeblock { background: var(--bg3); padding: 12px; border-radius: 4px; font-
       </div>
     </div>
 
+    <div class="card" id="kiosk-banner-card">
+      <div class="card-header"><h2>Kiosk Banner</h2></div>
+      <div class="card-body">
+        <p class="muted" style="font-size:0.82rem;margin-top:0">
+          Post a message on the public Status Board (issue #138) for a set amount of time
+          &mdash; e.g. "Node will be down from 1AM to 2AM for maintenance." Visible to every
+          kiosk viewer, even with the chat panel hidden.
+        </p>
+        <div id="kiosk-banner-status" style="margin-bottom:12px"></div>
+        <div id="kiosk-banner-form-wrap">
+          <div class="form-row">
+            <div class="form-group" style="flex:1;min-width:260px">
+              <label class="form-label">Message</label>
+              <textarea id="kb-message" class="val-input" rows="2" maxlength="300"
+                        style="width:100%;resize:vertical"
+                        placeholder="Node will be down from 1AM to 2AM for updates and maintenance."></textarea>
+            </div>
+          </div>
+          <div class="form-row" style="align-items:flex-end">
+            <div class="form-group">
+              <label class="form-label">Duration</label>
+              <select id="kb-duration" class="val-input">
+                <option value="15">15 minutes</option>
+                <option value="30" selected>30 minutes</option>
+                <option value="60">1 hour</option>
+                <option value="120">2 hours</option>
+                <option value="240">4 hours</option>
+                <option value="480">8 hours</option>
+                <option value="1440">24 hours</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <button class="btn btn-primary" onclick="kioskBannerSet()">Show Banner</button>
+            </div>
+          </div>
+          <div id="kiosk-banner-msg" style="font-size:0.82rem;margin-top:4px"></div>
+        </div>
+      </div>
+    </div>
+
     <div class="card">
       <div class="card-header"><h2>Connect / Disconnect</h2></div>
       <div class="card-body">
@@ -3170,6 +3210,7 @@ sudo bash /opt/HenWen/tx-spike/apply.sh</pre>
             <tr><td>User Management (create Owners)</td><td style="text-align:center">&#10003;</td><td style="text-align:center">&#10003;</td><td style="text-align:center">&#8212;</td><td style="text-align:center">&#8212;</td></tr>
             <tr><td>Raw Editor (direct rpt.conf edit)</td><td style="text-align:center">&#10003;</td><td style="text-align:center">&#10003;</td><td style="text-align:center">&#8212;</td><td style="text-align:center">&#8212;</td></tr>
             <tr><td>Node Lockout (lock out all other roles)</td><td style="text-align:center">&#10003;</td><td style="text-align:center">&#8212;</td><td style="text-align:center">&#8212;</td><td style="text-align:center">&#8212;</td></tr>
+            <tr><td>Kiosk Banner (post a board-wide notice)</td><td style="text-align:center">&#10003;</td><td style="text-align:center">&#8212;</td><td style="text-align:center">&#8212;</td><td style="text-align:center">&#8212;</td></tr>
             <tr><td>Exempt from another owner's lockout</td><td style="text-align:center">&#10003;</td><td style="text-align:center">&#8212;</td><td style="text-align:center">&#8212;</td><td style="text-align:center">&#8212;</td></tr>
           </tbody>
         </table>
@@ -3443,7 +3484,7 @@ function showPage(id) {
   currentPage = id;
 
   if      (id === 'dashboard')    { refreshDashboard(); startDiagPolling(); }
-  else if (id === 'node-control') { loadFavorites(); startNcPolling(); startFavStatusPolling(); renderNodeLockoutCard(); }
+  else if (id === 'node-control') { loadFavorites(); startNcPolling(); startFavStatusPolling(); renderNodeLockoutCard(); renderKioskBannerCard(); }
   else if (id === 'raw-editor')   rawLoad();
   else if (id === 'backups')        loadBackups();
   else if (id === 'conn-history')   chLoad(0);
@@ -5022,6 +5063,67 @@ async function toggleNodeLockout(node, locked, btn) {
     return;
   }
   renderNodeLockoutCard();
+}
+
+/* ── Kiosk Banner (issue #138) ─────────────────────────────────────────────
+   Read side reuses /api/status/board (public, already the source of truth
+   for the kiosk itself) rather than a dedicated GET route, same as
+   renderNodeLockoutCard() above -- every role can see whether a banner is
+   currently showing, but only Owner gets the controls to set/clear one
+   (enforced again server-side on POST/DELETE /api/kiosk/banner). */
+async function renderKioskBannerCard() {
+  var statusEl = document.getElementById('kiosk-banner-status');
+  var formWrap = document.getElementById('kiosk-banner-form-wrap');
+  if (!statusEl || !formWrap) return;
+  var isOwner = window._henwenRole === 'owner';
+  formWrap.style.display = isOwner ? '' : 'none';
+
+  var r = await api('/api/status/board');
+  if (!r.ok) { statusEl.innerHTML = '<span class="muted">Error loading banner status.</span>'; return; }
+  var banner = r.data.banner;
+  if (banner && banner.message) {
+    var remaining = Math.max(0, banner.expires_at - (Date.now()/1000));
+    statusEl.innerHTML =
+      '<div style="display:flex;align-items:center;justify-content:space-between;gap:10px;flex-wrap:wrap;' +
+      'padding:8px 10px;border:1px solid var(--accent);border-radius:6px">' +
+        '<div><strong>Showing now:</strong> ' + esc(banner.message) +
+          '<div class="muted" style="font-size:0.78rem">' +
+            (banner.created_by ? 'Set by ' + esc(banner.created_by) + ' &mdash; ' : '') +
+            _fmtDuration(remaining) + ' left</div></div>' +
+        (isOwner ? '<button class="btn btn-sm btn-danger" onclick="kioskBannerClear()">Clear Now</button>' : '') +
+      '</div>';
+  } else {
+    statusEl.innerHTML = '<span class="muted">No banner currently showing.</span>';
+  }
+}
+
+async function kioskBannerSet() {
+  var msgEl = document.getElementById('kb-message');
+  var message = msgEl.value.trim();
+  var statusMsg = document.getElementById('kiosk-banner-msg');
+  if (!message) { statusMsg.textContent = 'Enter a message.'; statusMsg.style.color = 'var(--danger)'; return; }
+  var duration = parseInt(document.getElementById('kb-duration').value, 10);
+  var r = await api('/api/kiosk/banner', {
+    method:  'POST',
+    headers: {'Content-Type': 'application/json'},
+    body:    JSON.stringify({message: message, duration_min: duration}),
+  });
+  if (!r.ok) {
+    statusMsg.textContent = r.data.error || 'Error setting banner';
+    statusMsg.style.color = 'var(--danger)';
+    return;
+  }
+  statusMsg.textContent = 'Banner posted.';
+  statusMsg.style.color = 'var(--green)';
+  msgEl.value = '';
+  setTimeout(function(){ statusMsg.textContent = ''; }, 3000);
+  renderKioskBannerCard();
+}
+
+async function kioskBannerClear() {
+  var r = await api('/api/kiosk/banner', { method: 'DELETE' });
+  if (!r.ok) { alert('Error: ' + (r.data.error || r.status)); return; }
+  renderKioskBannerCard();
 }
 
 /* ── Node Control — live status polling ──────────────────────────────────── */
@@ -6776,6 +6878,10 @@ async function applyRoleNav() {
      controls themselves only render for Owner — enforced again server-side
      in /api/nodes/<node>/lockout. */
   renderNodeLockoutCard();
+  /* Kiosk Banner card (Node Control page): same "status visible to all,
+     controls Owner-only" split as Node Lockout just above — enforced again
+     server-side on POST/DELETE /api/kiosk/banner. */
+  renderKioskBannerCard();
 }
 
 window.addEventListener('DOMContentLoaded', async function() {

--- a/templates/status-accessible.html
+++ b/templates/status-accessible.html
@@ -95,6 +95,14 @@ label { display: block; font-weight: 600; margin-bottom: 0.3rem; }
 }
 .banner ul { margin: 0.4rem 0 0 1.3rem; }
 
+/* Owner-triggered kiosk banner (issue #138) — same box shape as .banner
+   above but --accent-bordered rather than --danger-bordered, since this is
+   an operational notice the Owner posted, not a weather warning. */
+.kiosk-banner {
+  margin-top: 1rem; padding: 0.9rem 1.1rem; border: 3px solid var(--accent);
+  border-radius: 8px; background: var(--bg2); color: var(--fg); font-weight: 600;
+}
+
 .live-status {
   margin-top: 1rem; padding: 0.7rem 1rem; border: 2px solid var(--border);
   border-radius: 8px; background: var(--bg2); color: var(--fg2); font-size: 0.95rem;
@@ -154,6 +162,8 @@ footer { margin-top: 2.5rem; padding-top: 1rem; border-top: 2px solid var(--bord
 </header>
 
 <div id="alert-banner" class="banner" role="alert" hidden></div>
+
+<div id="kiosk-banner" class="kiosk-banner" role="status" aria-live="polite" hidden></div>
 
 <div id="live-status" class="live-status" role="status" aria-live="polite">Loading node status&hellip;</div>
 
@@ -391,6 +401,19 @@ async function refreshBoard() {
   var data = await r.json();
   var nodes = data.nodes || [];
   window._lastBoardNodes = nodes;
+
+  var kioskBanner = document.getElementById('kiosk-banner');
+  var bannerText = (data.banner && data.banner.message) || '';
+  if (bannerText) {
+    /* Only touch the DOM (and so only re-announce via aria-live) when the
+       text actually changes, matching refreshNwsAlerts()'s own
+       _lastNwsKey guard below. */
+    if (kioskBanner.textContent !== bannerText) kioskBanner.textContent = bannerText;
+    kioskBanner.hidden = false;
+  } else {
+    kioskBanner.hidden = true;
+    kioskBanner.textContent = '';
+  }
 
   var area = document.getElementById('node-status-area');
   /* refreshBoard() replaces this area's innerHTML every 4s (duration/keyed

--- a/templates/status.html
+++ b/templates/status.html
@@ -344,6 +344,22 @@ html, body { height: 100%; background: var(--bg); color: var(--text);
 .nws-alert-item.nws-sev-advisory strong { color: var(--warn); }
 @keyframes nws-scroll { from { transform: translateX(0); } to { transform: translateX(-50%); } }
 
+/* ── Kiosk banner: Owner-triggered notice (issue #138), shown for a fixed
+   duration the Owner picks in Manager > Node Control. Deliberately its own
+   bar rather than folded into the weather ticker or NWS bar -- this is a
+   one-off message the Owner is actively pointing at, not a recurring feed
+   item, and needs to read as distinct from both. Static text (no scroll
+   track like .nws-alert-bar), since a single short notice has no need to
+   loop, and wraps instead of clipping so a longer message stays readable. */
+.kiosk-banner-bar {
+  background: rgba(90,140,255,.12); border: 1px solid var(--accent); border-radius: 7px;
+  padding: 7px 14px; display: flex; align-items: flex-start; gap: 10px;
+  font-size: 0.9rem; min-height: 32px;
+}
+.kiosk-banner-icon { color: var(--accent); flex-shrink: 0; margin-top: 0.1em; }
+.kiosk-banner-text { flex: 1; min-width: 0; color: var(--text); font-weight: 500;
+  overflow-wrap: anywhere; }
+
 /* ── Content area: Node/Map | Connected Nodes | Favorites ──
    A 12-col x 24-row grid built from `fr` tracks, not fixed px, so it always
    fills exactly the space .content-area has (same "fits the viewport, never
@@ -1319,6 +1335,11 @@ html, body { height: 100%; background: var(--bg); color: var(--text);
     <path d="M12 16v-4" />
     <path d="M12 8h.01" />
   </symbol>
+  <symbol id="icon-megaphone" viewBox="0 0 24 24">
+    <path d="M11 6a13 13 0 0 0 8.4-2.8A1 1 0 0 1 21 4v12a1 1 0 0 1-1.6.8A13 13 0 0 0 11 14H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2z" />
+    <path d="M6 14a12 12 0 0 0 2.4 7.2 2 2 0 0 0 3.2-2.4A8 8 0 0 1 10 14" />
+    <path d="M8 6v8" />
+  </symbol>
   <symbol id="icon-menu" viewBox="0 0 24 24">
     <path d="M4 5h16" />
     <path d="M4 12h16" />
@@ -1562,6 +1583,14 @@ html, body { height: 100%; background: var(--bg); color: var(--text);
     <div class="nws-alert-track-wrap" id="nws-alert-track-wrap">
       <div class="nws-alert-track" id="nws-alert-track"></div>
     </div>
+  </div>
+
+  <!-- Owner-triggered kiosk banner (issue #138) — updated from the same
+       /api/status/board refresh cycle as everything above, so it appears
+       within one refreshBoard() tick of the Owner setting it. -->
+  <div class="kiosk-banner-bar" id="kiosk-banner-bar" style="display:none">
+    <span class="kiosk-banner-icon"><svg class="icon"><use href="#icon-megaphone"></use></svg></span>
+    <div class="kiosk-banner-text" id="kiosk-banner-text"></div>
   </div>
 
   <!-- Content -->
@@ -4496,6 +4525,20 @@ async function refreshBoard() {
         warnBar.style.display = 'flex';
       } else {
         warnBar.style.display = 'none';
+      }
+    }
+
+    /* Owner-triggered kiosk banner (issue #138) — data.banner is null once
+       the server-side expires_at check in _get_active_kiosk_banner() lapses,
+       so this bar disappears on its own within one refreshBoard() tick of
+       expiring, with no separate countdown/timer needed client-side. */
+    var kioskBannerBar = document.getElementById('kiosk-banner-bar');
+    if (kioskBannerBar) {
+      if (data.banner && data.banner.message) {
+        document.getElementById('kiosk-banner-text').textContent = data.banner.message;
+        kioskBannerBar.style.display = 'flex';
+      } else {
+        kioskBannerBar.style.display = 'none';
       }
     }
     recordKeyedHistory(allLinked);

--- a/tests/test_kiosk_banner.py
+++ b/tests/test_kiosk_banner.py
@@ -1,0 +1,162 @@
+"""Tests for the Owner-triggered kiosk banner (issue #138):
+_get_active_kiosk_banner()'s expiry logic, and the owner-gating on
+POST/DELETE /api/kiosk/banner, mirroring tests/test_discord_relay.py's
+pattern for an owner-only route. The banner also rides along on the public
+/api/status/board payload -- covered here too, since that's how the kiosk
+itself (and the Manager card) actually reads it.
+"""
+import time
+
+import app
+
+
+def _login(client, username):
+    row = app.get_db().execute("SELECT * FROM users WHERE username=?", (username,)).fetchone()
+    with client.session_transaction() as sess:
+        sess["logged_in"]      = True
+        sess["username"]       = username
+        sess["role"]           = row["role"]
+        sess["user_id"]        = row["id"]
+        sess["password_epoch"] = row["password_epoch"]
+        sess["idle_timeout"]   = app.SESSION_IDLE_TIMEOUT
+        sess["sid"]            = "test-sid-" + username
+
+
+class TestGetActiveKioskBanner:
+    def test_none_when_never_set(self, fresh_db):
+        assert app._get_active_kiosk_banner() is None
+
+    def test_active_banner_returned(self, fresh_db):
+        fresh_db.execute(
+            "INSERT INTO kiosk_banner (id, message, expires_at, created_by, created_at) "
+            "VALUES (1, 'Node down for maintenance', ?, 'owner1', ?)",
+            (time.time() + 300, time.time()),
+        )
+        fresh_db.commit()
+        banner = app._get_active_kiosk_banner()
+        assert banner is not None
+        assert banner["message"] == "Node down for maintenance"
+        assert banner["created_by"] == "owner1"
+
+    def test_expired_banner_not_returned(self, fresh_db):
+        fresh_db.execute(
+            "INSERT INTO kiosk_banner (id, message, expires_at, created_by, created_at) "
+            "VALUES (1, 'Old notice', ?, 'owner1', ?)",
+            (time.time() - 1, time.time() - 300),
+        )
+        fresh_db.commit()
+        assert app._get_active_kiosk_banner() is None
+
+    def test_cleared_banner_not_returned(self, fresh_db):
+        fresh_db.execute(
+            "INSERT INTO kiosk_banner (id, message, expires_at, created_by, created_at) "
+            "VALUES (1, '', NULL, 'owner1', ?)",
+            (time.time(),),
+        )
+        fresh_db.commit()
+        assert app._get_active_kiosk_banner() is None
+
+
+class TestKioskBannerSetRoute:
+    def test_requires_login(self, client, create_user):
+        create_user("owner1", role="owner")
+        resp = client.post("/api/kiosk/banner", json={"message": "hi", "duration_min": 30})
+        assert resp.status_code == 401
+
+    def test_rejects_admin(self, client, create_user):
+        create_user("owner1", role="owner")
+        create_user("admin1", password="password12345", role="admin")
+        _login(client, "admin1")
+        resp = client.post("/api/kiosk/banner", json={"message": "hi", "duration_min": 30})
+        assert resp.status_code == 403
+
+    def test_rejects_superuser(self, client, create_user):
+        create_user("owner1", role="owner")
+        create_user("su1", password="password12345", role="superuser")
+        _login(client, "su1")
+        resp = client.post("/api/kiosk/banner", json={"message": "hi", "duration_min": 30})
+        assert resp.status_code == 403
+
+    def test_owner_can_set_and_it_persists(self, client, create_user):
+        create_user("owner1", role="owner")
+        _login(client, "owner1")
+        resp = client.post("/api/kiosk/banner",
+                            json={"message": "Node down 1-2AM", "duration_min": 60})
+        assert resp.status_code == 200
+        banner = app._get_active_kiosk_banner()
+        assert banner["message"] == "Node down 1-2AM"
+        assert banner["created_by"] == "owner1"
+        # expires_at should be ~60 minutes out
+        assert 3595 <= (banner["expires_at"] - time.time()) <= 3600
+
+    def test_rejects_empty_message(self, client, create_user):
+        create_user("owner1", role="owner")
+        _login(client, "owner1")
+        resp = client.post("/api/kiosk/banner", json={"message": "   ", "duration_min": 30})
+        assert resp.status_code == 400
+
+    def test_rejects_overlong_message(self, client, create_user):
+        create_user("owner1", role="owner")
+        _login(client, "owner1")
+        resp = client.post("/api/kiosk/banner",
+                            json={"message": "x" * 301, "duration_min": 30})
+        assert resp.status_code == 400
+
+    def test_rejects_zero_duration(self, client, create_user):
+        create_user("owner1", role="owner")
+        _login(client, "owner1")
+        resp = client.post("/api/kiosk/banner", json={"message": "hi", "duration_min": 0})
+        assert resp.status_code == 400
+
+    def test_rejects_duration_over_max(self, client, create_user):
+        create_user("owner1", role="owner")
+        _login(client, "owner1")
+        resp = client.post("/api/kiosk/banner", json={"message": "hi", "duration_min": 10081})
+        assert resp.status_code == 400
+
+    def test_second_set_replaces_first(self, client, create_user):
+        create_user("owner1", role="owner")
+        _login(client, "owner1")
+        client.post("/api/kiosk/banner", json={"message": "First", "duration_min": 30})
+        client.post("/api/kiosk/banner", json={"message": "Second", "duration_min": 15})
+        banner = app._get_active_kiosk_banner()
+        assert banner["message"] == "Second"
+
+
+class TestKioskBannerClearRoute:
+    def test_rejects_non_owner(self, client, create_user):
+        create_user("owner1", role="owner")
+        create_user("admin1", password="password12345", role="admin")
+        _login(client, "owner1")
+        client.post("/api/kiosk/banner", json={"message": "hi", "duration_min": 30})
+        _login(client, "admin1")
+        resp = client.delete("/api/kiosk/banner")
+        assert resp.status_code == 403
+        assert app._get_active_kiosk_banner() is not None
+
+    def test_owner_can_clear(self, client, create_user):
+        create_user("owner1", role="owner")
+        _login(client, "owner1")
+        client.post("/api/kiosk/banner", json={"message": "hi", "duration_min": 30})
+        assert app._get_active_kiosk_banner() is not None
+        resp = client.delete("/api/kiosk/banner")
+        assert resp.status_code == 200
+        assert app._get_active_kiosk_banner() is None
+
+
+class TestKioskBannerOnStatusBoard:
+    def test_board_reports_null_when_no_banner(self, client, create_user):
+        create_user("owner1", role="owner")
+        resp = client.get("/api/status/board")
+        assert resp.status_code == 200
+        assert resp.get_json()["banner"] is None
+
+    def test_board_reports_active_banner_without_login(self, client, create_user):
+        create_user("owner1", role="owner")
+        _login(client, "owner1")
+        client.post("/api/kiosk/banner", json={"message": "Net at 7PM tonight", "duration_min": 30})
+        client.post("/logout")  # board is public; confirm it's readable logged-out too
+        resp = client.get("/api/status/board")
+        assert resp.status_code == 200
+        banner = resp.get_json()["banner"]
+        assert banner["message"] == "Net at 7PM tonight"


### PR DESCRIPTION
## Summary
- Owner can post a board-wide notice from Manager > Node Control ("Kiosk Banner" card) for a chosen duration (15 min – 7 days), e.g. "Node will be down from 1AM to 2AM for updates and maintenance."
- The banner rides along on the existing public, 2s-polled `/api/status/board` payload rather than a new poll loop, so it appears on the kiosk within one refresh cycle and needs no client-side countdown/timer — it just disappears once the server-side expiry check lapses.
- Shown on both the main kiosk board (`status.html`) and the accessible view (`status-accessible.html`, `role="status"` region) so it isn't missed by screen-reader users.
- Same owner-only gate as Node Lockout (`role != 'owner'`), since this is visible to every anonymous kiosk viewer — read-only status is visible to all roles on the Manager card, matching Node Lockout's existing split.
- New `kiosk_banner` singleton table; `POST`/`DELETE /api/kiosk/banner` for set/clear.

Closes #138.

## Test plan
- [x] `./venv/bin/pytest` — 666 passed (17 new tests in `tests/test_kiosk_banner.py` covering expiry logic, owner-gating, validation, and the `/api/status/board` payload)
- [x] Deployed to `/opt/HenWen` and restarted the live service; confirmed `/api/status/board` returns `"banner": null` with no active banner
- [ ] Manual click-through of the new Manager card (set/clear, duration options) — left for the user to confirm the UI feels right before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RyXFaGsPQ7TCDWDkDXokV