### PR TITLE
Harden squash-idle against the same class of KeyError as #146

### DIFF
--- a/app.py
+++ b/app.py
@@ -7817,6 +7817,16 @@ def api_status_squash_idle():
     with _kiosk_temp_lock:
         if key in _kiosk_temp_conns:
             _kiosk_temp_conns[key]['no_timeout'] = True
+            # Defensive, not expected to ever fire in practice (every entry
+            # this could find is created fully-formed elsewhere) — but
+            # info['last_active'] below is a hard requirement, and an
+            # unguarded bracket-index on shared, multiply-written state is
+            # exactly the shape of bug fixed in api_status_board() (see its
+            # comment). setdefault() here is deliberately at the field level
+            # (fill in a missing value on an already-known-to-exist dict),
+            # not the collection level (create-if-absent an entire entry)
+            # that caused that bug — the two aren't the same operation.
+            _kiosk_temp_conns[key].setdefault('last_active', time.time())
         else:
             _kiosk_temp_conns[key] = {'permanent': False, 'monitor': False,
                                       'no_timeout': True, 'last_active': time.time()}


### PR DESCRIPTION
## Summary
Follow-up audit requested after #146: checked every other Status Board/kiosk button touching `_kiosk_temp_conns` for the same failure shape (an unguarded bracket-index into a dict this app doesn't fully control the shape of).

Found one more, in `/api/status/squash-idle`: its "entry already exists" branch set `no_timeout` but never touched `last_active`, then unconditionally read `info['last_active']` two lines later. Not currently reachable (every `_kiosk_temp_conns` entry is created fully-formed as of #146), but it's the same landmine shape — one future partial-entry site anywhere and this button breaks the same way the board did.

## Fix
`_kiosk_temp_conns[key].setdefault('last_active', time.time())` in that branch — field-level default-fill on an already-known-to-exist dict, not the collection-level `setdefault(key, {})` that caused #146.

## Audited and already safe (no changes needed)
- `/api/status/restore-idle`, `/api/status/reset-idle` — both set `last_active` unconditionally before reading it back
- `/api/status/connect` — always writes a fully-formed dict
- `/api/status/disconnect`, `/api/ami/disconnect` — don't touch `_kiosk_temp_conns`
- AMI poll loop's idle-tracking/idle-disconnect passes — already defensive `.get()`, or safe by construction
- Smart Connector's disconnect-others-first logic — already `.get('permanent')`

## Test plan
- [x] `python3 -m py_compile app.py`
- [x] Deployed live to `/opt/HenWen`, restarted, confirmed `/api/status/board` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RyXFaGsPQ7TCDWDkDXokV