### PR TITLE
Add a Nominatim-down health check, wired into Manager > Alerts

### DIFF
--- a/app.py
+++ b/app.py
@@ -3653,6 +3653,20 @@ _GEOCODE_FAIL_TTL = 300      # retry a failed lookup after 5 min, not never
 _geocode_lock   = threading.Lock()
 _geocode_last   = [0.0]      # time of last Nominatim request (rate-limit: 1 req/s)
 _geocode_rlock  = threading.Lock()
+# Extra global backoff held only while Nominatim is actively 429ing us, on
+# top of the flat 1.1s pace above. Without this, one 429 didn't slow
+# anything down at all -- the very next queued location (a different query
+# string, but the same offending IP as far as Nominatim's concerned) was
+# tried again a flat 1.1s later, at the exact pace that had just gotten
+# rejected. Confirmed live (2026-09-11): that cascaded into 20-80s bursts
+# of up to 46 consecutive 429s in a row, since nothing here ever backed off
+# from the pace provoking them -- each burst only ended when it happened to
+# outlast whatever window Nominatim was enforcing. Doubles on each
+# consecutive 429 (capped), resets to zero on the next success.
+_geocode_backoff_until = [0.0]
+_geocode_backoff_sec   = [0.0]
+_GEOCODE_BACKOFF_FLOOR_SEC = 5.0
+_GEOCODE_BACKOFF_CAP_SEC   = 120.0
 
 
 def _geocode_cache_get(loc):
@@ -3678,9 +3692,11 @@ def _geocode(location: str):
         if hit:
             return cached_result
 
-    # Nominatim: at most 1 request per 1.1 seconds
+    # Nominatim: at most 1 request per 1.1 seconds, plus whatever extra
+    # backoff a recent 429 has put us into (see _geocode_backoff_until above).
     with _geocode_rlock:
-        wait = 1.1 - (time.time() - _geocode_last[0])
+        wait = max(1.1 - (time.time() - _geocode_last[0]),
+                   _geocode_backoff_until[0] - time.time())
         if wait > 0:
             time.sleep(wait)
         _geocode_last[0] = time.time()
@@ -3690,9 +3706,17 @@ def _geocode(location: str):
             with urlreq.urlopen(req, timeout=10) as resp:
                 results = json.loads(resp.read())
             result = {"lat": float(results[0]["lat"]), "lon": float(results[0]["lon"])} if results else None
+            _geocode_backoff_sec[0] = 0.0  # any success clears an earlier backoff
         except Exception as e:
             log("WARN", f"[GEOCODE] '{loc}': {e}")
             result = None
+            if getattr(e, 'code', None) == 429:
+                _geocode_backoff_sec[0] = min(
+                    _GEOCODE_BACKOFF_CAP_SEC,
+                    max(_GEOCODE_BACKOFF_FLOOR_SEC, _geocode_backoff_sec[0] * 2))
+                _geocode_backoff_until[0] = time.time() + _geocode_backoff_sec[0]
+                log("WARN", f"[GEOCODE] Rate-limited by Nominatim — backing off "
+                            f"{_geocode_backoff_sec[0]:.0f}s before the next request")
 
     with _geocode_lock:
         expires_at = None if result is not None else time.time() + _GEOCODE_FAIL_TTL

--- a/app.py
+++ b/app.py
@@ -793,6 +793,13 @@ def get_db():
         # api_forgot_password() the moment a reset is requested, since that's
         # already an event, not a value to sample.
         conn.execute("ALTER TABLE alert_config ADD COLUMN on_password_reset_request INTEGER NOT NULL DEFAULT 1")
+    if 'on_geocode_down' not in _alert_cols:
+        # Same "external network dependency, poll-loop-sampled" shape as
+        # on_dns_stuck -- see _check_geocode_health(). Defaults on for the
+        # same reason on_dns_stuck does: a silently-broken map/APRS location
+        # feed is the kind of thing an owner would want to know about rather
+        # than discover by noticing missing pins.
+        conn.execute("ALTER TABLE alert_config ADD COLUMN on_geocode_down INTEGER NOT NULL DEFAULT 1")
     conn.commit()
     # Singleton config for the NWS severe weather auto-announcement poller —
     # separate from alert_config (that's push notifications; this is
@@ -2854,6 +2861,7 @@ def _poll_loop():
             # AMI state + CPU temp + disk usage alerts — outside lock, OK to do network I/O here
             _check_alerts(_ami_connected, get_cpu_temp(), get_disk_usage())
             _check_asterisk_dns_health()
+            _check_geocode_health()
 
         except Exception as outer:
             log("ERROR", f"[AMI-POLL] Unexpected outer error: {outer}")
@@ -3668,6 +3676,22 @@ _geocode_backoff_sec   = [0.0]
 _GEOCODE_BACKOFF_FLOOR_SEC = 5.0
 _GEOCODE_BACKOFF_CAP_SEC   = 120.0
 
+# Health tracking for the Manager > Alerts "Nominatim Geocoding Down" toggle
+# -- see _check_geocode_health(). Deliberately NOT keyed off backoff/failure
+# *counts*: a burst of dozens of 429s that resolves itself in under two
+# minutes (the normal, expected case the backoff above already handles) is
+# not something an owner needs paged about. What actually indicates a real
+# outage is going a long time with zero successful lookups *despite active
+# attempts* -- so this tracks last-attempt and last-success timestamps
+# instead, and _check_geocode_health() alerts on a sustained gap between them.
+_geocode_last_attempt  = [0.0]
+_geocode_last_success  = [time.time()]  # seeded at import so a quiet start isn't mistaken for an outage
+_geocode_alert_active  = [False]
+_geocode_health_last_check = [0.0]
+_GEOCODE_HEALTH_CHECK_INTERVAL = 30     # seconds between checks (self-throttled)
+_GEOCODE_RECENT_ATTEMPT_SEC    = 120    # an attempt this recent counts as "actively trying"
+_GEOCODE_DOWN_SEC              = 900    # 15 min with no success, while actively trying = "down"
+
 
 def _geocode_cache_get(loc):
     """Return (hit, result) -- hit is False for a miss or an expired failure."""
@@ -3694,19 +3718,25 @@ def _geocode(location: str):
 
     # Nominatim: at most 1 request per 1.1 seconds, plus whatever extra
     # backoff a recent 429 has put us into (see _geocode_backoff_until above).
+    just_recovered = False
     with _geocode_rlock:
         wait = max(1.1 - (time.time() - _geocode_last[0]),
                    _geocode_backoff_until[0] - time.time())
         if wait > 0:
             time.sleep(wait)
         _geocode_last[0] = time.time()
+        _geocode_last_attempt[0] = _geocode_last[0]
         try:
             url = NOMINATIM_URL.format(urlparse.quote_plus(loc))
             req = urlreq.Request(url, headers={"User-Agent": "HenWen/1.0 (ham radio node manager)"})
             with urlreq.urlopen(req, timeout=10) as resp:
                 results = json.loads(resp.read())
             result = {"lat": float(results[0]["lat"]), "lon": float(results[0]["lon"])} if results else None
-            _geocode_backoff_sec[0] = 0.0  # any success clears an earlier backoff
+            _geocode_backoff_sec[0]  = 0.0  # any success clears an earlier backoff
+            _geocode_last_success[0] = time.time()
+            if _geocode_alert_active[0]:
+                _geocode_alert_active[0] = False
+                just_recovered = True
         except Exception as e:
             log("WARN", f"[GEOCODE] '{loc}': {e}")
             result = None
@@ -3718,10 +3748,60 @@ def _geocode(location: str):
                 log("WARN", f"[GEOCODE] Rate-limited by Nominatim — backing off "
                             f"{_geocode_backoff_sec[0]:.0f}s before the next request")
 
+    # _send_alert() does real network I/O (up to ~8s per enabled provider) --
+    # deliberately fired here, after _geocode_rlock is released, so a slow
+    # notification send can't stall every other queued geocode lookup behind
+    # this one request the way holding the lock through it would.
+    if just_recovered:
+        cfg = _get_alert_config()
+        if cfg and cfg["enabled"] and cfg["on_geocode_down"]:
+            log("INFO", "[ALERTS] Nominatim geocoding recovered")
+            _send_alert("HenWen: Nominatim Geocoding Recovered",
+                        "Nominatim is resolving locations again.", "default")
+
     with _geocode_lock:
         expires_at = None if result is not None else time.time() + _GEOCODE_FAIL_TTL
         _geocode_cache[loc] = (result, expires_at)
     return result
+
+
+def _check_geocode_health():
+    """Alert if Nominatim geocoding has gone a long time with no successful
+    lookup despite active attempts -- the Manager > Alerts "Nominatim
+    Geocoding Down" toggle. Deliberately does NOT fire on the short, bursty
+    429 storms _geocode()'s own backoff already absorbs (confirmed live:
+    up to 46 consecutive 429s within ~80s, self-resolving) -- only a
+    sustained gap between attempts and successes means the map/APRS
+    location feed is actually stuck, not just riding out a normal burst.
+    Self-throttled the same way _check_asterisk_dns_health() is."""
+    now = time.time()
+    if now - _geocode_health_last_check[0] < _GEOCODE_HEALTH_CHECK_INTERVAL:
+        return
+    _geocode_health_last_check[0] = now
+
+    cfg = _get_alert_config()
+    if not cfg or not cfg["enabled"] or not cfg["on_geocode_down"]:
+        return
+
+    actively_trying = (now - _geocode_last_attempt[0]) < _GEOCODE_RECENT_ATTEMPT_SEC
+    down = actively_trying and (now - _geocode_last_success[0]) > _GEOCODE_DOWN_SEC
+
+    if down and not _geocode_alert_active[0]:
+        _geocode_alert_active[0] = True
+        log("WARN", f"[ALERTS] Nominatim geocoding appears down (no successful "
+                     f"lookup in over {_GEOCODE_DOWN_SEC // 60} min despite active attempts)")
+        _send_alert(
+            "HenWen: Nominatim Geocoding Down",
+            "Map pin locations aren't resolving — Nominatim has rejected or failed "
+            "every geocode attempt for a sustained period. This is usually external "
+            "rate-limiting that clears on its own; if it doesn't, new/unresolved "
+            "node locations will stay missing from the map.",
+            "default")
+    # Recovery is detected and alerted from inside _geocode() itself, at the
+    # moment a real success happens -- not here. This function only ever
+    # turns the alert ON; doing "not down anymore" turn-off here too would
+    # also fire if attempts simply stopped happening for a while (nobody
+    # asking isn't the same as it having recovered).
 
 
 # Non-blocking geocode for request hot paths (the Status Board). Returns the
@@ -6300,6 +6380,7 @@ def api_alerts_get_config():
             "on_dns_stuck": 1,
             "on_disk_high": 1, "disk_pct_threshold": 90,
             "on_password_reset_request": 1,
+            "on_geocode_down": 1,
         })
     return jsonify(dict(cfg))
 
@@ -6314,8 +6395,8 @@ def api_alerts_save_config():
             ntfy_topic, pushover_token, pushover_user,
             on_ami_disconnect, on_ami_reconnect, on_cpu_temp_high, cpu_temp_threshold,
             on_node_connect, on_node_disconnect, watch_nodes, on_dns_stuck,
-            on_disk_high, disk_pct_threshold, on_password_reset_request)
-           VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            on_disk_high, disk_pct_threshold, on_password_reset_request, on_geocode_down)
+           VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             1 if data.get("enabled")           else 0,
             1 if data.get("ntfy_enabled")       else 0,
@@ -6337,6 +6418,7 @@ def api_alerts_save_config():
             1 if data.get("on_disk_high")      else 0,
             int(data.get("disk_pct_threshold", 90)),
             1 if data.get("on_password_reset_request") else 0,
+            1 if data.get("on_geocode_down")   else 0,
         )
     )
     db.commit()

--- a/templates/henwen-manager.html
+++ b/templates/henwen-manager.html
@@ -1260,6 +1260,10 @@ pre.codeblock { background: var(--bg3); padding: 12px; border-radius: 4px; font-
             <label class="switch"><input type="checkbox" id="al-dns-stuck"><span class="slider"></span></label>
           </div>
           <div class="toggle-row">
+            <div class="toggle-info"><div class="toggle-key">Nominatim Geocoding Down</div><div class="toggle-desc">Map/APRS location lookups have failed for a sustained period — new node locations won't show on the map until it clears</div></div>
+            <label class="switch"><input type="checkbox" id="al-geocode-down"><span class="slider"></span></label>
+          </div>
+          <div class="toggle-row">
             <div class="toggle-info">
               <div class="toggle-key">Low Disk Space</div>
               <div class="toggle-desc">
@@ -4617,6 +4621,7 @@ async function alLoad() {
   document.getElementById('al-cpu-high').checked  = !!d.on_cpu_temp_high;
   document.getElementById('al-cpu-thr').value     = d.cpu_temp_threshold || 80;
   document.getElementById('al-dns-stuck').checked = !!d.on_dns_stuck;
+  document.getElementById('al-geocode-down').checked = !!d.on_geocode_down;
   document.getElementById('al-disk-high').checked = !!d.on_disk_high;
   document.getElementById('al-disk-thr').value    = d.disk_pct_threshold || 90;
   document.getElementById('al-pwreset').checked   = !!d.on_password_reset_request;
@@ -4659,6 +4664,7 @@ async function alSave() {
     on_cpu_temp_high:   document.getElementById('al-cpu-high').checked  ? 1 : 0,
     cpu_temp_threshold: parseInt(document.getElementById('al-cpu-thr').value) || 80,
     on_dns_stuck:       document.getElementById('al-dns-stuck').checked ? 1 : 0,
+    on_geocode_down:    document.getElementById('al-geocode-down').checked ? 1 : 0,
     on_disk_high:       document.getElementById('al-disk-high').checked ? 1 : 0,
     disk_pct_threshold: parseInt(document.getElementById('al-disk-thr').value) || 90,
     on_password_reset_request: document.getElementById('al-pwreset').checked ? 1 : 0,


### PR DESCRIPTION
## Summary
Follow-up to #148 (the geocode 429-backoff fix). Adds a **"Nominatim Geocoding Down"** toggle to Manager > Alerts so the owner can be notified if map/APRS location lookups genuinely stop working, rather than just riding out the normal 429 bursts #148 already handles.

Modeled directly on the existing "Asterisk DNS Stuck" check (`_check_asterisk_dns_health`) — same self-throttled poll-loop shape, same `alert_config` column pattern (`ALTER TABLE` + `PRAGMA table_info` migration, default-on).

## Design choice: not failure-count-based
The DNS check alerts on N failures within a time window. I deliberately didn't copy that shape here: a burst of 30-46 429s that fully resolves in under two minutes (confirmed normal behavior in #148's investigation) would trip almost any reasonable failure-count threshold, and that's exactly the case the backoff fix is supposed to make a non-event.

Instead this tracks last-attempt/last-success timestamps. "Down" = actively trying to geocode for the last 2 minutes, with zero successes in the last 15 — a real sustained outage, not a survivable burst.

Recovery is fired from inside `_geocode()` itself, at the exact moment a real success happens — not inferred by the periodic checker from "attempts stopped happening," since attempts going quiet for a while isn't the same as the service having recovered.

One thing I caught while writing this: my first draft fired the recovery `_send_alert()` call while still holding `_geocode_rlock`. Fixed before deploying — that lock guards the shared rate limiter, and `_send_alert()` can take several seconds across multiple enabled providers, which would've stalled every other queued geocode lookup right when we're trying to catch back up from an outage.

## Test plan
- [x] `python3 -m py_compile app.py`
- [x] Standalone script against a real (temp) sqlite DB: `alert_config` round-trips the new column, the down-alert fires once and doesn't duplicate while already active, a real `_geocode()` success clears it and fires the recovery alert
- [x] Re-ran #148's backoff test to confirm no regression from touching the same function twice
- [x] Deployed live to `/opt/HenWen`, restarted, confirmed `/api/status/board` returns 200 and startup is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RyXFaGsPQ7TCDWDkDXokV