### PR TITLE
Fix DTMF page swallowing errors instead of showing them

### DIFF
--- a/templates/henwen-manager.html
+++ b/templates/henwen-manager.html
@@ -7530,23 +7530,17 @@ async function dtmfSend() {
   var seq  = _dtmfSeq;
   if (!seq) { res.innerHTML = '<span style="color:var(--warn)">Enter a sequence first.</span>'; return; }
   res.innerHTML = '<span class="muted">Sending...</span>';
-  try {
-    var r = await apiFetch('/api/dtmf/send', {
-      method: 'POST', headers: {'Content-Type':'application/json'},
-      body: JSON.stringify({ node: node, digits: seq })
-    });
-    var d = await r.json();
-    if (!r.ok) {
-      res.innerHTML = '<span style="color:var(--danger)">' + esc(d.error || 'Error') + '</span>';
-      dtmfAddHistory('DTMF ' + seq + ' → node ' + node, false, d.error || 'Error');
-    } else {
-      res.innerHTML = '<span style="color:var(--green)">Sent: ' + esc(seq) + '</span>';
-      dtmfAddHistory('DTMF ' + seq + ' → node ' + node, true, d.raw || '');
-      dtmfClear();
-    }
-  } catch(e) {
-    res.innerHTML = '<span style="color:var(--danger)">' + esc(String(e)) + '</span>';
-    dtmfAddHistory('DTMF ' + seq + ' → node ' + node, false, String(e));
+  var r = await api('/api/dtmf/send', {
+    method: 'POST', headers: {'Content-Type':'application/json'},
+    body: JSON.stringify({ node: node, digits: seq })
+  });
+  if (!r.ok) {
+    res.innerHTML = '<span style="color:var(--danger)">' + esc(r.data.error || 'Error') + '</span>';
+    dtmfAddHistory('DTMF ' + seq + ' → node ' + node, false, r.data.error || 'Error');
+  } else {
+    res.innerHTML = '<span style="color:var(--green)">Sent: ' + esc(seq) + '</span>';
+    dtmfAddHistory('DTMF ' + seq + ' → node ' + node, true, r.data.raw || '');
+    dtmfClear();
   }
 }
 
@@ -7568,22 +7562,17 @@ async function dtmfFunction(family, fn) {
     body.confirm = true;
   }
   res.innerHTML = '<span class="muted">Sending ' + label + '...</span>';
-  try {
-    var r = await apiFetch('/api/dtmf/' + family, {
-      method: 'POST', headers: {'Content-Type':'application/json'},
-      body: JSON.stringify(body)
-    });
-    var d = await r.json();
-    if (!r.ok) {
-      res.innerHTML = '<span style="color:var(--danger)">' + esc(d.error || 'Error') + '</span>';
-      dtmfAddHistory(label + ' → node ' + node, false, d.error || 'Error');
-    } else {
-      res.innerHTML = '<span style="color:var(--green)">' + label + ' sent</span>';
-      dtmfAddHistory(label + ' → node ' + node, true, d.raw || '');
-    }
-  } catch(e) {
-    res.innerHTML = '<span style="color:var(--danger)">' + esc(String(e)) + '</span>';
-    dtmfAddHistory(label + ' → node ' + node, false, String(e));
+  var r = await api('/api/dtmf/' + family, {
+    method: 'POST', headers: {'Content-Type':'application/json'},
+    body: JSON.stringify(body)
+  });
+  if (!r.ok) {
+    res.innerHTML = '<span style="color:var(--danger)">' + esc(r.data.error || 'Error') + '</span>';
+    dtmfAddHistory(label + ' → node ' + node, false, r.data.error || 'Error');
+  } else {
+    res.innerHTML = '<span style="color:var(--green)">' + label + ' sent' +
+      (r.data.raw ? ' — ' + esc(r.data.raw) : '') + '</span>';
+    dtmfAddHistory(label + ' → node ' + node, true, r.data.raw || '');
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #142 (partially — see caveat below).

The Test DTMF page's `dtmfSend()`/`dtmfFunction()` (Parrot Mode Enable/Disable and every other quick-action COP/status button) called raw `apiFetch()` + `r.json()` directly, instead of going through this app's own `api()` wrapper — the only place that recognizes a Flask-WTF CSRF failure (a non-JSON HTML error page) and turns it into a readable "session expired" message. Any such failure on the DTMF page instead threw inside `r.json()`, landing in the catch block as a raw `SyntaxError: Unexpected token <...` next to a small, easy-to-miss result span — which reads as the button doing nothing at all ("silently fails").

This also now surfaces the command's raw app_rpt output directly in the result line, not just in the (collapsed) history panel, so a real app_rpt-side rejection is visible immediately.

## What this does NOT explain

I directly verified against the live box's AMI/app_rpt connection that `cop 21`/`cop 22` (Parrot Mode Enable/Disable) correctly flip app_rpt's internal `parrot_ena` flag when sent exactly the way `/api/dtmf/cop` sends them (`rpt cmd <node> cop <n>` over AMI) — confirmed via `rpt xnode <node>` before/after, then reverted. So the AMI transport and the Flask route are not themselves broken, and this PR doesn't change either.

One real candidate for why parrot mode specifically might not audibly do anything on this box: node `1999` in `rpt.conf` (the USRP/digital-bridge node) has `telemdefault = 0`, which turns off telemetry output entirely — and parrot playback rides on the same telemetry output path. If that node (rather than the real radio node `643930`) was selected in the DTMF page's node dropdown when this was tested, `parrot_ena` would still correctly flip, but nothing would ever play back, by design. Worth confirming which node was used before closing #142 outright.

## Test plan
- [x] `python3 -m py_compile app.py` (unaffected, template-only change)
- [x] Deployed to the live install (`/opt/HenWen`), `systemctl restart HenWen`, confirmed service comes back up and `/status` serves 200
- [x] Verified live against real AMI/app_rpt: `cop 21` → `rpt xnode <node>` shows `parrot_ena=1`; `cop 22` → `parrot_ena=0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012G2Jvcbtvnrk3GTuiHH9qY